### PR TITLE
Add `jkl ai agents-md` command, AGENTS.md updater, config path helpers, and Fig completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,10 @@ Use this as the default playbook for coding agents in this repository.
 - Preserve existing CLI behavior and keybindings unless requested.
 - Update docs when commands or behavior change.
 
+## Basic JKL Instructions
+
+- Do not invoke the TUI command (`jkl tui`) from automated agents.
+- Upsert session metadata: `jkl upsert <session_name...> [--session-id <session_id>] [--status <status>] [--context <text...>]`
+- Upsert pane metadata: `jkl upsert <session_name...> --pane-id <pane_id> [--status <status>] [--context <text...>]`
+- Rename a session entry: `jkl rename <session_id> <session_name...>`
+- Sync persisted metadata with live tmux state: `jkl sync`

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Each archive should contain the `jkl` binary at the top level.
 - Sync persisted metadata with live tmux state: `jkl sync`
 - Uninstall binary from current location: `jkl uninstall [--purge-data]`
 - Pane status selector: `jkl tui --pane-state --session-name <session_name...> --pane-id <pane_id>`
+- Append basic JKL instructions to AGENTS.md files: `jkl ai agents-md [path]`
 
 Multi-word session names or context can be passed without quotes; use `--` to terminate positional values if needed.
 

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -62,6 +62,22 @@ const completionSpec: Fig.Spec = {
   ],
   subcommands: [
     {
+      name: "ai",
+      description: "AI-focused utilities",
+      subcommands: [
+        {
+          name: "agents-md",
+          description: "Append basic JKL instructions to AGENTS.md files",
+          args: {
+            name: "path",
+            description: "Root directory to search (defaults to current)",
+            isOptional: true,
+            template: "folders",
+          },
+        },
+      ],
+    },
+    {
       name: "tui",
       description: "Open the interactive TUI",
       options: [

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,118 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const BASIC_INSTRUCTIONS: &str = r#"## Basic JKL Instructions
+
+- Do not invoke the TUI command (`jkl tui`) from automated agents.
+- Upsert session metadata: `jkl upsert <session_name...> [--session-id <session_id>] [--status <status>] [--context <text...>]`
+- Upsert pane metadata: `jkl upsert <session_name...> --pane-id <pane_id> [--status <status>] [--context <text...>]`
+- Rename a session entry: `jkl rename <session_id> <session_name...>`
+- Sync persisted metadata with live tmux state: `jkl sync`
+"#;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AppendSummary {
+    pub files_updated: usize,
+    pub files_skipped: usize,
+}
+
+pub fn append_basic_instructions(root: &Path) -> Result<AppendSummary, std::io::Error> {
+    let mut summary = AppendSummary::default();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let entries = match fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            let entry_path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                if file_type.is_symlink() {
+                    continue;
+                }
+                stack.push(entry_path);
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            if entry.file_name() != "AGENTS.md" {
+                continue;
+            }
+            let updated = append_instructions_to_file(&entry_path)?;
+            if updated {
+                summary.files_updated += 1;
+            } else {
+                summary.files_skipped += 1;
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn append_instructions_to_file(path: &Path) -> Result<bool, std::io::Error> {
+    let contents = fs::read_to_string(path)?;
+    if contents.contains("## Basic JKL Instructions") {
+        return Ok(false);
+    }
+    let mut next = String::with_capacity(contents.len() + BASIC_INSTRUCTIONS.len() + 2);
+    next.push_str(contents.trim_end());
+    next.push_str("\n\n");
+    next.push_str(BASIC_INSTRUCTIONS);
+    fs::write(path, next)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| std::time::Duration::from_nanos(0))
+            .as_nanos();
+        dir.push(format!("{}-{}", prefix, nanos));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn append_basic_instructions_updates_nested_agents() {
+        let root = temp_dir("agents-append");
+        let nested = root.join("nested");
+        fs::create_dir_all(&nested).expect("create nested");
+        let root_file = root.join("AGENTS.md");
+        let nested_file = nested.join("AGENTS.md");
+        fs::write(&root_file, "# Root\n").expect("write root");
+        fs::write(&nested_file, "# Nested\n").expect("write nested");
+
+        let summary = append_basic_instructions(&root).expect("append");
+
+        assert_eq!(summary.files_updated, 2);
+        let root_contents = fs::read_to_string(&root_file).expect("read root");
+        let nested_contents = fs::read_to_string(&nested_file).expect("read nested");
+        assert!(root_contents.contains("## Basic JKL Instructions"));
+        assert!(nested_contents.contains("## Basic JKL Instructions"));
+    }
+
+    #[test]
+    fn append_basic_instructions_skips_existing_section() {
+        let root = temp_dir("agents-skip");
+        let path = root.join("AGENTS.md");
+        fs::write(&path, BASIC_INSTRUCTIONS).expect("write instructions");
+
+        let summary = append_basic_instructions(&root).expect("append");
+
+        assert_eq!(summary.files_updated, 0);
+        assert_eq!(summary.files_skipped, 1);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    Ai(AiArgs),
     Tui(TuiArgs),
     Upsert(UpsertArgs),
     Rename(RenameArgs),
@@ -34,6 +35,24 @@ struct TuiArgs {
     /// The ID of the pane to open the status selector popup for
     #[arg(long)]
     pane_id: Option<String>,
+}
+
+#[derive(Args)]
+struct AiArgs {
+    #[command(subcommand)]
+    command: AiCommands,
+}
+
+#[derive(Subcommand)]
+enum AiCommands {
+    AgentsMd(AgentsMdArgs),
+}
+
+#[derive(Args)]
+struct AgentsMdArgs {
+    /// Root directory to search for AGENTS.md files.
+    #[arg(default_value = ".", value_name = "PATH")]
+    root: String,
 }
 
 #[derive(Args)]
@@ -68,7 +87,7 @@ struct UpdateArgs {
 
 #[derive(Args)]
 struct UninstallArgs {
-    /// Also remove ~/.config/jkl (session metadata + logs).
+    /// Also remove the jkl config directory (session metadata + logs).
     #[arg(long)]
     purge_data: bool,
 }
@@ -77,6 +96,10 @@ pub fn run() -> Result<()> {
     let cli = Cli::parse();
     debug!("cli parsed");
     match cli.command {
+        Commands::Ai(args) => {
+            info!("command=ai");
+            handle_ai(args)?
+        }
         Commands::Tui(args) => {
             info!("command=tui");
             handle_tui(args)?
@@ -103,6 +126,20 @@ pub fn run() -> Result<()> {
         }
     };
     Ok(())
+}
+
+fn handle_ai(args: AiArgs) -> Result<(), anyhow::Error> {
+    match args.command {
+        AiCommands::AgentsMd(args) => {
+            let root = std::path::Path::new(&args.root);
+            let summary = crate::agents::append_basic_instructions(root)?;
+            println!(
+                "Updated {} AGENTS.md files (skipped {})",
+                summary.files_updated, summary.files_skipped
+            );
+            Ok(())
+        }
+    }
 }
 
 fn handle_tui(args: TuiArgs) -> Result<(), TuiError> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -69,6 +69,8 @@ pub enum ContextError {
     FailedToSave(String),
     #[error("Invalid status: {0}")]
     InvalidStatus(String),
+    #[error("Missing config directory")]
+    MissingConfigDir,
 }
 
 pub fn session_key(session_name: &str) -> String {
@@ -425,11 +427,10 @@ fn save_contexts(contexts: &ContextJson) -> Result<(), ContextError> {
 }
 
 /// Get the path to the context file
-/// Should return $HOME/.config/jkl/session_context.json
+/// Should return the OS config directory + /jkl/session_context.json
 fn context_path() -> Result<PathBuf, ContextError> {
-    let home = std::env::var("HOME")?;
-    let base_dir = PathBuf::from(home).join(".config");
-    let path = base_dir.join("jkl").join("session_context.json");
+    let base_dir = crate::paths::config_dir().ok_or(ContextError::MissingConfigDir)?;
+    let path = base_dir.join("session_context.json");
     debug!("resolved context path={}", path.display());
     Ok(path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+mod agents;
 mod cli;
 mod context;
+mod paths;
 #[cfg(test)]
 mod test_utils;
 mod tmux;
@@ -16,10 +18,8 @@ fn main() -> Result<(), anyhow::Error> {
 fn init_logging() -> Result<std::path::PathBuf, anyhow::Error> {
     use flexi_logger::{Cleanup, Criterion, FileSpec, Logger, Naming};
 
-    let home_dir = std::env::var("HOME")?;
-    let log_directory = std::path::PathBuf::from(home_dir)
-        .join(".config")
-        .join("jkl");
+    let log_directory =
+        crate::paths::config_dir().ok_or_else(|| anyhow::anyhow!("missing config directory"))?;
 
     // Ensure log directory exists
     std::fs::create_dir_all(&log_directory)?;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+
+pub fn config_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+            .map(|dir| dir.join("jkl"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
+            return Some(dir.join("jkl"));
+        }
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .map(|dir| dir.join(".config").join("jkl"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::EnvGuard;
+
+    #[test]
+    #[cfg(unix)]
+    fn config_dir_respects_xdg_config_home() {
+        let mut env = EnvGuard::new("paths-xdg-config");
+        let base = env.temp_dir().join("xdg-config");
+        std::fs::create_dir_all(&base).expect("create xdg config dir");
+        env.set_var("XDG_CONFIG_HOME", &base);
+
+        let dir = config_dir().expect("config dir");
+        assert_eq!(dir, base.join("jkl"));
+    }
+
+    #[test]
+    fn config_dir_defaults_to_home_config() {
+        let mut env = EnvGuard::new("paths-home-config");
+        let home = env.set_temp_home();
+        env.remove_var("XDG_CONFIG_HOME");
+
+        let dir = config_dir().expect("config dir");
+        let expected = if cfg!(windows) {
+            home.join("AppData").join("Roaming").join("jkl")
+        } else {
+            home.join(".config").join("jkl")
+        };
+        assert_eq!(dir, expected);
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -49,6 +49,18 @@ impl EnvGuard {
         let home = self.temp_dir.join("home");
         fs::create_dir_all(&home).expect("create temp home");
         self.set_var("HOME", &home);
+        #[cfg(unix)]
+        {
+            let config_home = home.join(".config");
+            fs::create_dir_all(&config_home).expect("create temp config");
+            self.set_var("XDG_CONFIG_HOME", &config_home);
+        }
+        #[cfg(windows)]
+        {
+            let appdata = home.join("AppData").join("Roaming");
+            fs::create_dir_all(&appdata).expect("create temp appdata");
+            self.set_var("APPDATA", &appdata);
+        }
         home
     }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -16,15 +16,13 @@ struct UninstallSummary {
 
 pub fn run(purge_data: bool) -> Result<()> {
     let exe_path = std::env::current_exe().context("resolve current executable path")?;
-    let home_dir = if purge_data {
-        Some(
-            PathBuf::from(std::env::var("HOME").context("read HOME for config cleanup")?),
-        )
+    let config_dir = if purge_data {
+        Some(crate::paths::config_dir().context("resolve config directory for cleanup")?)
     } else {
         None
     };
 
-    let summary = uninstall_paths(&exe_path, home_dir.as_deref(), purge_data)?;
+    let summary = uninstall_paths(&exe_path, config_dir.as_deref(), purge_data)?;
 
     if summary.removed_binary {
         println!("Removed {}", summary.binary_path.display());
@@ -55,7 +53,7 @@ pub fn run(purge_data: bool) -> Result<()> {
 
 fn uninstall_paths(
     exe_path: &Path,
-    home_dir: Option<&Path>,
+    config_dir: Option<&Path>,
     purge_data: bool,
 ) -> Result<UninstallSummary> {
     let binary_path = exe_path.to_path_buf();
@@ -70,11 +68,10 @@ fn uninstall_paths(
         .with_context(|| format!("remove helper at {}", helper_path.display()))?;
 
     let (removed_config, config_path) = if purge_data {
-        let home = home_dir.context("missing home directory for config cleanup")?;
-        let path = home.join(".config").join("jkl");
+        let path = config_dir.context("missing config directory for cleanup")?;
         let removed = remove_dir_if_exists(&path)
             .with_context(|| format!("remove config directory at {}", path.display()))?;
-        (Some(removed), Some(path))
+        (Some(removed), Some(path.to_path_buf()))
     } else {
         (None, None)
     };
@@ -140,14 +137,13 @@ mod tests {
     fn uninstall_paths_purges_config_when_requested() {
         let env = EnvGuard::new("uninstall-purge-config");
         let exe = env.temp_dir().join("jkl");
-        let home = env.temp_dir().join("home");
-        let config_dir = home.join(".config").join("jkl");
+        let config_dir = env.temp_dir().join("config").join("jkl");
 
         fs::create_dir_all(&config_dir).expect("create config dir");
         fs::write(config_dir.join("session_context.json"), "{}").expect("write config");
         fs::write(&exe, "bin").expect("write exe");
 
-        let summary = uninstall_paths(&exe, Some(&home), true).expect("uninstall");
+        let summary = uninstall_paths(&exe, Some(&config_dir), true).expect("uninstall");
         assert_eq!(summary.removed_config, Some(true));
         assert!(!config_dir.exists());
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use self_update::backends::github::ReleaseList;
 use self_update::update::Release;
 use std::path::PathBuf;


### PR DESCRIPTION
### Motivation

- Provide an automated, recursive utility to append a standardized "Basic JKL Instructions" block into `AGENTS.md` files to guide automated agents. 
- Group AI-related tools under a new `ai` command namespace to allow future AI utilities and to avoid agents invoking interactive TUI workflows. 
- Replace ad-hoc `HOME` usage with a cross-platform config directory helper to correctly locate logs and config on different platforms. 

### Description

- Add `src/agents.rs` implementing `append_basic_instructions()` which recursively finds `AGENTS.md` files and appends the `BASIC_INSTRUCTIONS` block when missing, and include unit tests for nested discovery and skip-on-existing behavior. 
- Add a new CLI command group and subcommand: `Ai(AiArgs)` -> `agents-md` implemented in `src/cli.rs`, with `handle_ai()` calling `crate::agents::append_basic_instructions()` and printing a summary. 
- Add cross-platform helper `src/paths.rs` exposing `config_dir()` and update `src/main.rs`, `src/context.rs`, and `src/uninstall.rs` to use it for log and config file locations and to return a `MissingConfigDir` error where appropriate. 
- Update test utilities in `src/test_utils.rs` to set platform-appropriate temp env vars (`XDG_CONFIG_HOME` on unix and `APPDATA` on Windows) for reliable tests. 
- Update docs and tooling: append guidance to `AGENTS.md`, add `jkl ai agents-md [path]` to `README.md`, and update Fig completions at `completions/fig/jkl.ts` to include the new `ai agents-md` completion. 

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran the full test suite with `cargo test --locked` and all tests passed (`47 passed; 0 failed`). 
- Verified Fig completion update by adding the `ai agents-md` spec to `completions/fig/jkl.ts` and ensuring no test regressions occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988039b23e8833283cd3a67f40cc689)