### PR TITLE
Fix Fig autocomplete init path creating nested .fig directory

### DIFF
--- a/scripts/sync-fig-autocomplete.sh
+++ b/scripts/sync-fig-autocomplete.sh
@@ -62,10 +62,14 @@ EOF
     exit 1
   fi
 
-  parent_dir="$(dirname "$FIG_REPO_DIR")"
-  mkdir -p "$parent_dir"
+  init_dir="$(dirname "$FIG_REPO_DIR")"
+  if [[ "$FIG_REPO_DIR" == "$HOME/.fig/autocomplete" ]]; then
+    init_dir="$HOME"
+  fi
+
+  mkdir -p "$init_dir"
   (
-    cd "$parent_dir"
+    cd "$init_dir"
     npx @withfig/autocomplete-tools@latest init
   )
 


### PR DESCRIPTION
### Motivation
- The Fig sync script could initialize the repo from the wrong working directory and create a nested `~/.fig/.fig/autocomplete` when using the default `~/.fig/autocomplete` location.

### Description
- Update `scripts/sync-fig-autocomplete.sh` to set `init_dir` to `$(dirname "$FIG_REPO_DIR")` and override it to `$HOME` when `FIG_REPO_DIR` is the default `~/.fig/autocomplete`, then run `npx @withfig/autocomplete-tools@latest init` from `init_dir`, preserving custom `FIG_AUTOCOMPLETE_DIR` behavior.

### Testing
- Ran `bash -n scripts/sync-fig-autocomplete.sh` to validate the script syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9309fe00833290507cc244460a20)