### PR TITLE
Improve invalid status error with valid options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,10 +124,12 @@ fn handle_tui(args: TuiArgs) -> Result<(), TuiError> {
 
 fn handle_upsert(args: UpsertArgs) -> Result<(), ContextError> {
     let status: Option<AgentStatus> = match args.status {
-        Some(s) => Some(
-            s.parse::<AgentStatus>()
-                .map_err(|e| ContextError::InvalidStatus(e.to_string()))?,
-        ),
+        Some(s) => Some(s.parse::<AgentStatus>().map_err(|_| {
+            ContextError::InvalidStatus(format!(
+                "{s}. Valid options: {}",
+                valid_statuses().join(", ")
+            ))
+        })?),
         None => None,
     };
     let session_name = join_tokens(args.session_name);
@@ -186,6 +188,10 @@ fn join_tokens(tokens: Vec<String>) -> String {
     tokens.join(" ")
 }
 
+fn valid_statuses() -> Vec<&'static str> {
+    vec!["working", "waiting", "done", "none"]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,7 +223,12 @@ mod tests {
 
         let err = handle_upsert(args).expect_err("expected invalid status");
         match err {
-            ContextError::InvalidStatus(_) => {}
+            ContextError::InvalidStatus(message) => {
+                assert_eq!(
+                    message,
+                    "not-a-status. Valid options: working, waiting, done, none"
+                );
+            }
             other => panic!("unexpected error: {other:?}"),
         }
     }


### PR DESCRIPTION
### Motivation
- Make the `upsert` failure for unknown status values more helpful by showing the rejected input and the canonical list of valid status variants so users and agents can correct the value quickly.

### Description
- Update `handle_upsert` in `src/cli.rs` to map parse errors into `ContextError::InvalidStatus` that includes the invalid input and a comma-separated list of valid statuses via `valid_statuses()`.
- Add a small helper `valid_statuses()` in `src/cli.rs` that returns the canonical status strings `working`, `waiting`, `done`, and `none`.
- Tighten the `handle_upsert_rejects_invalid_status` unit test to assert the full improved error message.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test --locked handle_upsert_rejects_invalid_status -- --exact` which passed.
- Ran `cargo test --locked` and the full test suite passed (all tests ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a932de0908332b0fe3e69cb357a23)