### PR TITLE
tui: show meta shortcut labels for sessions 10+ (M-a, M-b, ...)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -560,7 +560,7 @@ impl App {
             RowItem::Session(row) => self
                 .session_index_by_id
                 .get(&row.id)
-                .map(|index| format!("{index}: {}", row.name))
+                .map(|index| format!("{}: {}", session_shortcut_label(*index), row.name))
                 .unwrap_or_else(|| row.name.clone()),
             RowItem::Pane(row) => format!("  └─ {}", pane_label(row)),
         }
@@ -937,6 +937,20 @@ fn meta_jump_index(c: char) -> Option<usize> {
     if offset < 26 { Some(10 + offset) } else { None }
 }
 
+fn session_shortcut_label(index: usize) -> String {
+    if index < 10 {
+        return index.to_string();
+    }
+
+    let letter_offset = index - 10;
+    if letter_offset < 26 {
+        let letter = (b'a' + letter_offset as u8) as char;
+        return format!("M-{letter}");
+    }
+
+    index.to_string()
+}
+
 fn normalize_field(value: Option<&String>) -> String {
     value
         .map(|value| value.trim())
@@ -1137,6 +1151,17 @@ mod tests {
         let app = App::new_with_filter(sessions, Box::new(|_, _| Ok(String::new()))).expect("app");
         assert_eq!(app.row_label(&app.rows[0]), "0: alpha");
         assert_eq!(app.row_label(&app.rows[1]), "1: beta");
+    }
+
+    #[test]
+    fn row_label_uses_meta_shortcuts_after_nine() {
+        let sessions = (0..12)
+            .map(|index| session_row(&format!("@{index}"), &format!("session-{index}")))
+            .collect();
+        let app = App::new_with_filter(sessions, Box::new(|_, _| Ok(String::new()))).expect("app");
+
+        assert_eq!(app.row_label(&app.rows[10]), "M-a: session-10");
+        assert_eq!(app.row_label(&app.rows[11]), "M-b: session-11");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The list view currently renders raw numeric prefixes for session indices greater than 9, which does not match the `Alt+<letter>` (meta) keybindings the UI supports.
- Users expect sessions 10+ to be addressable with meta shortcuts like `M-a`, `M-b`, etc., so the labels should reflect those shortcuts.

### Description
- Replace the numeric prefix in `row_label` with a call to a new helper `session_shortcut_label` that maps indices `< 10` to digits and indices `10..=35` to `M-a`..`M-z`, with a numeric fallback for out-of-range values, implemented in `src/tui.rs`.
- Update the `row_label` formatting to use `session_shortcut_label` for session rows so displayed labels match available meta keybindings.
- Add a unit test `row_label_uses_meta_shortcuts_after_nine` to assert that indices `10` and `11` are rendered as `M-a` and `M-b` respectively.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Executed `cargo test --locked tui::tests` and all tests passed, including the new `row_label_uses_meta_shortcuts_after_nine` test (11 passed; 0 failed).
- Verified the change is confined to `src/tui.rs` and the new behavior is covered by unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c95a8780c8332ae68d3ed5473d9b7)