### PR TITLE
Add window-aware metadata, TUI hierarchy, CLI flags, and Fig completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ Each archive should contain the `jkl` binary at the top level.
 - Launch the TUI: `jkl tui`
 - Quit the TUI: `q`, `Esc`, or `Ctrl+C` (Ctrl+C exits search first)
 - Navigate rows: `↑`/`↓` or `j`/`k`
-- Expand/collapse panes: `l`/`h`
+- Expand/collapse session details (windows + panes): `l`/`h`
 - Refresh pane list: `r`
 - Search sessions: `/` (type to filter, `Esc` to exit search)
 - Switch to session: `Enter`
 - Upsert session metadata: `jkl upsert <session_name...> [--session-id <session_id>] [--status <status>] [--context <text...>]`
-- Upsert pane metadata: `jkl upsert <session_name...> --pane-id <pane_id> [--status <status>] [--context <text...>]`
+- Upsert pane metadata: `jkl upsert <session_name...> --pane-id <pane_id> [--window-id <window_id>] [--window-name <window_name>] [--status <status>] [--context <text...>]`
 - Rename session entry: `jkl rename <session_id> <session_name...>`
 - Sync persisted metadata with live tmux state: `jkl sync`
 - Uninstall binary from current location: `jkl uninstall [--purge-data]`
@@ -258,12 +258,20 @@ Shape (keyed by `blake3(session_name)`):
 {
   "2f0d7b3b5e3b9b1d4b4b5b8b8e2e2e9a2d2d4d5f2f0f5e5f2d9b3f1a5c8e": {
     "session_name": "work",
-    "status": "idle",
-    "context": "my project",
+    "session_status": "waiting",
+    "session_context": "my project",
+    "windows": {
+      "@10": {
+        "window_id": "@10",
+        "window_name": "editor"
+      }
+    },
     "panes": {
       "%1": {
-        "status": "working",
-        "context": "focus time"
+        "window_id": "@10",
+        "window_name": "editor",
+        "pane_status": "working",
+        "pane_context": "focus time"
       }
     }
   }
@@ -283,7 +291,7 @@ Cleanup/repair example:
 jkl sync
 ```
 
-`jkl sync` keeps only sessions/panes that still exist in tmux. Session matching is ID-first; if no ID match is found it falls back to session name. When a session is matched by ID but the name changed, jkl updates `session_name` and re-keys the JSON entry to `blake3(new_session_name)`.
+`jkl sync` keeps only sessions/windows/panes that still exist in tmux. Session matching is ID-first; if no ID match is found it falls back to session name. When a session is matched by ID but the name changed, jkl updates `session_name` and re-keys the JSON entry to `blake3(new_session_name)`.
 
 Status values:
 
@@ -318,6 +326,8 @@ Arguments:
 Options:
       --session-id <SESSION_ID>
       --pane-id <PANE_ID>
+      --window-id <WINDOW_ID>
+      --window-name <WINDOW_NAME>
       --status <STATUS>
       --context <CONTEXT>...
 ```
@@ -325,7 +335,7 @@ Options:
 Examples:
 
 - `jkl upsert <session_name...> [--session-id <session_id>] [--status <status>] [--context <text...>]` upserts session metadata.
-- `jkl upsert <session_name...> --pane-id <pane_id> [--status <status>] [--context <text...>]` upserts pane metadata.
+- `jkl upsert <session_name...> --pane-id <pane_id> [--window-id <window_id>] [--window-name <window_name>] [--status <status>] [--context <text...>]` upserts pane metadata.
 - `jkl sync` removes stale session/pane metadata and migrates renamed sessions using tmux `session_id`.
 
 Sample commands:

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -47,6 +47,40 @@ const paneIdGenerator: Fig.Generator = {
       }),
 };
 
+
+const windowIdGenerator: Fig.Generator = {
+  script: 'tmux list-windows -a -F "#{window_id}|#{window_name}|#{session_name}" 2>/dev/null',
+  postProcess: (output) =>
+    output
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [windowId, windowName, sessionName] = line.split("|");
+        return {
+          name: windowId,
+          description:
+            sessionName && windowName
+              ? `tmux window: ${sessionName}:${windowName}`
+              : "tmux window id",
+        };
+      }),
+};
+
+const windowNameGenerator: Fig.Generator = {
+  script: 'tmux list-windows -a -F "#{window_name}|#{session_name}" 2>/dev/null',
+  postProcess: (output) =>
+    output
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [windowName, sessionName] = line.split("|");
+        return {
+          name: windowName,
+          description: sessionName ? `tmux session: ${sessionName}` : "tmux window",
+        };
+      }),
+};
+
 const completionSpec: Fig.Spec = {
   name: "jkl",
   description: "Inspect agent statuses in tmux sessions",
@@ -112,6 +146,22 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "pane_id",
             generators: paneIdGenerator,
+          },
+        },
+        {
+          name: "--window-id",
+          description: "Window id when updating a pane entry",
+          args: {
+            name: "window_id",
+            generators: windowIdGenerator,
+          },
+        },
+        {
+          name: "--window-name",
+          description: "Human-friendly window name",
+          args: {
+            name: "window_name",
+            generators: windowNameGenerator,
           },
         },
         {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,10 @@ struct UpsertArgs {
     #[arg(long)]
     pane_id: Option<String>,
     #[arg(long)]
+    window_id: Option<String>,
+    #[arg(long)]
+    window_name: Option<String>,
+    #[arg(long)]
     pane_name: Option<String>,
     #[arg(long)]
     status: Option<String>,
@@ -146,6 +150,8 @@ fn handle_upsert(args: UpsertArgs) -> Result<(), ContextError> {
         return crate::context::upsert_pane(
             &session_name,
             &pane_id,
+            args.window_id,
+            args.window_name,
             args.pane_name,
             status,
             context,
@@ -217,6 +223,8 @@ mod tests {
             session_id: None,
             pane_id: None,
             pane_name: None,
+            window_id: None,
+            window_name: None,
             status: Some("not-a-status".to_string()),
             context: None,
         };
@@ -243,6 +251,8 @@ mod tests {
             session_id: Some("sid".to_string()),
             pane_id: None,
             pane_name: None,
+            window_id: None,
+            window_name: None,
             status: Some("Working".to_string()),
             context: Some(vec!["hello".to_string(), "world".to_string()]),
         };
@@ -268,7 +278,9 @@ mod tests {
             session_name: vec!["Alpha".to_string()],
             session_id: None,
             pane_id: Some("%1".to_string()),
+            window_id: Some("@1".to_string()),
             pane_name: Some("planner".to_string()),
+            window_name: Some("editor".to_string()),
             status: Some("waiting".to_string()),
             context: Some(vec!["pane".to_string(), "ctx".to_string()]),
         };
@@ -278,6 +290,8 @@ mod tests {
         let contexts = load_contexts().expect("load contexts");
         let session = contexts.get(&session_key("Alpha")).expect("session entry");
         let pane = session.panes.get("%1").expect("pane entry");
+        assert_eq!(pane.window_id.as_deref(), Some("@1"));
+        assert_eq!(pane.window_name.as_deref(), Some("editor"));
         assert_eq!(pane.pane_name.as_deref(), Some("planner"));
         assert_eq!(pane.pane_status, Some(AgentStatus::Waiting));
         assert_eq!(pane.pane_context.as_deref(), Some("pane ctx"));
@@ -352,13 +366,15 @@ esac
             Some("ctx".to_string()),
         )
         .expect("seed renamed session");
-        crate::context::upsert_pane("old-name", "%1", None, None, None).expect("pane keep");
-        crate::context::upsert_pane("old-name", "%9", None, None, None).expect("pane stale");
+        crate::context::upsert_pane("old-name", "%1", None, None, None, None, None)
+            .expect("pane keep");
+        crate::context::upsert_pane("old-name", "%9", None, None, None, None, None)
+            .expect("pane stale");
         crate::context::upsert_session("gone".to_string(), Some("@9".to_string()), None, None)
             .expect("seed stale session");
 
         env.set_var("TMUX_LIST_SESSIONS", "@1\tnew-name\n");
-        env.set_var("TMUX_LIST_PANES", "new-name\t%1\n");
+        env.set_var("TMUX_LIST_PANES", "new-name\t@10\teditor\t%1\n");
 
         handle_sync().expect("sync");
 
@@ -371,6 +387,13 @@ esac
         assert_eq!(renamed.session_name.as_deref(), Some("new-name"));
         assert_eq!(renamed.session_id.as_deref(), Some("@1"));
         assert!(renamed.panes.contains_key("%1"));
+        assert_eq!(
+            renamed
+                .panes
+                .get("%1")
+                .and_then(|pane| pane.window_id.as_deref()),
+            Some("@10")
+        );
         assert!(!renamed.panes.contains_key("%9"));
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,9 +27,19 @@ pub enum AgentStatus {
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct PaneContext {
     pub pane_id: Option<String>,
+    pub window_id: Option<String>,
+    pub window_name: Option<String>,
     pub pane_name: Option<String>,
     pub pane_status: Option<AgentStatus>,
     pub pane_context: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct WindowContext {
+    pub window_id: Option<String>,
+    pub window_name: Option<String>,
+    pub window_status: Option<AgentStatus>,
+    pub window_context: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
@@ -40,6 +50,8 @@ pub struct SessionContext {
     pub session_status: Option<AgentStatus>,
     pub session_context: Option<String>,
     #[serde(default)]
+    pub windows: WindowContextJson,
+    #[serde(default)]
     pub panes: PaneContextJson,
 }
 
@@ -47,6 +59,8 @@ pub type SessionKey = String;
 pub type PaneId = String;
 
 pub type ContextJson = HashMap<SessionKey, SessionContext>;
+pub type WindowId = String;
+pub type WindowContextJson = HashMap<WindowId, WindowContext>;
 pub type PaneContextJson = HashMap<PaneId, PaneContext>;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -181,6 +195,8 @@ pub fn upsert_session(
 pub fn upsert_pane(
     session_name: &str,
     pane_id: &str,
+    window_id: Option<String>,
+    window_name: Option<String>,
     pane_name: Option<String>,
     pane_status: Option<AgentStatus>,
     pane_context: Option<String>,
@@ -196,6 +212,27 @@ pub fn upsert_pane(
     let entry = contexts.entry(session_key(session_name)).or_default();
     entry.session_name = Some(session_name.to_string());
     let pane = entry.panes.entry(pane_id.to_string()).or_default();
+    pane.pane_id = Some(pane_id.to_string());
+
+    if let Some(window_id) = window_id {
+        pane.window_id = Some(window_id.clone());
+        if let Some(window_name) = window_name.clone() {
+            pane.window_name = Some(window_name.clone());
+            let window = entry.windows.entry(window_id.clone()).or_default();
+            if window.window_id.is_none() {
+                window.window_id = Some(window_id);
+            }
+            window.window_name = Some(window_name);
+        } else {
+            entry
+                .windows
+                .entry(window_id.clone())
+                .or_insert_with(|| WindowContext {
+                    window_id: Some(window_id),
+                    ..WindowContext::default()
+                });
+        }
+    }
 
     if let Some(pane_name) = pane_name {
         pane.pane_name = Some(pane_name);
@@ -260,11 +297,31 @@ pub fn sync_with_tmux(
         .collect();
 
     let mut live_pane_ids: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut live_window_ids: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut live_window_names: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut pane_window_by_session: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut pane_window_name_by_session: HashMap<String, HashMap<String, String>> = HashMap::new();
     for pane in live_panes {
         live_pane_ids
             .entry(pane.session_name.clone())
             .or_default()
             .insert(pane.pane_id.clone());
+        live_window_ids
+            .entry(pane.session_name.clone())
+            .or_default()
+            .insert(pane.window_id.clone());
+        live_window_names
+            .entry(pane.session_name.clone())
+            .or_default()
+            .insert(pane.window_id.clone(), pane.window_name.clone());
+        pane_window_by_session
+            .entry(pane.session_name.clone())
+            .or_default()
+            .insert(pane.pane_id.clone(), pane.window_id.clone());
+        pane_window_name_by_session
+            .entry(pane.session_name.clone())
+            .or_default()
+            .insert(pane.pane_id.clone(), pane.window_name.clone());
     }
 
     let mut summary = SyncSummary::default();
@@ -299,14 +356,44 @@ pub fn sync_with_tmux(
         context.session_id = Some(live_session.id.clone());
 
         let before_panes = context.panes.len();
+        let before_windows = context.windows.len();
         if let Some(live_ids) = live_pane_ids.get(&live_session.name) {
             context
                 .panes
                 .retain(|pane_id, _| live_ids.contains(pane_id));
+            if let Some(pane_to_window) = pane_window_by_session.get(&live_session.name) {
+                for (pane_id, pane) in &mut context.panes {
+                    if let Some(window_id) = pane_to_window.get(pane_id) {
+                        pane.window_id = Some(window_id.clone());
+                    }
+                    if let Some(window_name) = pane_window_name_by_session
+                        .get(&live_session.name)
+                        .and_then(|map| map.get(pane_id))
+                    {
+                        pane.window_name = Some(window_name.clone());
+                    }
+                }
+            }
         } else {
             context.panes.clear();
         }
+
+        if let Some(live_windows) = live_window_ids.get(&live_session.name) {
+            context
+                .windows
+                .retain(|window_id, _| live_windows.contains(window_id));
+            if let Some(window_names) = live_window_names.get(&live_session.name) {
+                for (window_id, window_name) in window_names {
+                    let window = context.windows.entry(window_id.clone()).or_default();
+                    window.window_id = Some(window_id.clone());
+                    window.window_name = Some(window_name.clone());
+                }
+            }
+        } else {
+            context.windows.clear();
+        }
         summary.removed_panes += before_panes.saturating_sub(context.panes.len());
+        let _ = before_windows;
 
         let key = session_key(&live_session.name);
         let target = synced.entry(key).or_default();
@@ -335,6 +422,15 @@ pub fn prune_panes(live_panes: &HashMap<String, HashSet<String>>) -> Result<(), 
         context
             .panes
             .retain(|pane_id, _| live_ids.contains(pane_id));
+
+        let live_windows: HashSet<String> = context
+            .panes
+            .values()
+            .filter_map(|pane| pane.window_id.clone())
+            .collect();
+        context
+            .windows
+            .retain(|window_id, _| live_windows.contains(window_id));
     }
     let after_count: usize = contexts.values().map(|ctx| ctx.panes.len()).sum();
     if after_count < before_count {
@@ -377,9 +473,32 @@ fn merge_context(target: &mut SessionContext, source: SessionContext) {
     if target.session_context.is_none() {
         target.session_context = source.session_context;
     }
+    for (window_id, window) in source.windows {
+        let WindowContext {
+            window_id: source_window_id,
+            window_name: source_window_name,
+            window_status: source_window_status,
+            window_context: source_window_context,
+        } = window;
+        let entry = target.windows.entry(window_id).or_default();
+        if entry.window_id.is_none() {
+            entry.window_id = source_window_id;
+        }
+        if entry.window_name.is_none() {
+            entry.window_name = source_window_name;
+        }
+        if entry.window_status.is_none() {
+            entry.window_status = source_window_status;
+        }
+        if entry.window_context.is_none() {
+            entry.window_context = source_window_context;
+        }
+    }
     for (pane_id, pane) in source.panes {
         let PaneContext {
             pane_id: source_pane_id,
+            window_id: source_window_id,
+            window_name: source_window_name,
             pane_name: source_pane_name,
             pane_status: source_pane_status,
             pane_context: source_pane_context,
@@ -387,6 +506,12 @@ fn merge_context(target: &mut SessionContext, source: SessionContext) {
         let entry = target.panes.entry(pane_id).or_default();
         if entry.pane_id.is_none() {
             entry.pane_id = source_pane_id;
+        }
+        if entry.window_id.is_none() {
+            entry.window_id = source_window_id;
+        }
+        if entry.window_name.is_none() {
+            entry.window_name = source_window_name;
         }
         if entry.pane_name.is_none() {
             entry.pane_name = source_pane_name;
@@ -518,6 +643,8 @@ mod tests {
         upsert_pane(
             "Alpha",
             "%1",
+            None,
+            None,
             Some("pane".to_string()),
             Some(AgentStatus::Waiting),
             Some("ctx".to_string()),
@@ -562,9 +689,9 @@ mod tests {
         let mut env = EnvGuard::new("context-prune");
         env.set_temp_home();
 
-        upsert_pane("Alpha", "%1", None, None, None).expect("pane 1");
-        upsert_pane("Alpha", "%2", None, None, None).expect("pane 2");
-        upsert_pane("Beta", "%3", None, None, None).expect("pane 3");
+        upsert_pane("Alpha", "%1", None, None, None, None, None).expect("pane 1");
+        upsert_pane("Alpha", "%2", None, None, None, None, None).expect("pane 2");
+        upsert_pane("Beta", "%3", None, None, None, None, None).expect("pane 3");
 
         let mut live = HashMap::new();
         live.insert("Alpha".to_string(), HashSet::from([String::from("%1")]));
@@ -592,12 +719,30 @@ mod tests {
             Some("ctx".to_string()),
         )
         .expect("seed renamed session");
-        upsert_pane("old-name", "%1", None, None, Some("keep".to_string())).expect("pane keep");
-        upsert_pane("old-name", "%9", None, None, Some("drop".to_string())).expect("pane drop");
+        upsert_pane(
+            "old-name",
+            "%1",
+            None,
+            None,
+            None,
+            None,
+            Some("keep".to_string()),
+        )
+        .expect("pane keep");
+        upsert_pane(
+            "old-name",
+            "%9",
+            None,
+            None,
+            None,
+            None,
+            Some("drop".to_string()),
+        )
+        .expect("pane drop");
 
         upsert_session("gone".to_string(), Some("@9".to_string()), None, None)
             .expect("seed stale session");
-        upsert_pane("gone", "%3", None, None, None).expect("stale pane");
+        upsert_pane("gone", "%3", None, None, None, None, None).expect("stale pane");
 
         let live_sessions = vec![TmuxSession {
             id: "@1".to_string(),
@@ -605,6 +750,8 @@ mod tests {
         }];
         let live_panes = vec![TmuxPane {
             session_name: "new-name".to_string(),
+            window_id: "@10".to_string(),
+            window_name: "editor".to_string(),
             pane_id: "%1".to_string(),
         }];
 
@@ -638,7 +785,7 @@ mod tests {
 
         upsert_session("alpha".to_string(), Some("@old".to_string()), None, None)
             .expect("seed session");
-        upsert_pane("alpha", "%1", None, None, None).expect("seed pane");
+        upsert_pane("alpha", "%1", None, None, None, None, None).expect("seed pane");
 
         let live_sessions = vec![TmuxSession {
             id: "@new".to_string(),
@@ -646,6 +793,8 @@ mod tests {
         }];
         let live_panes = vec![TmuxPane {
             session_name: "alpha".to_string(),
+            window_id: "@10".to_string(),
+            window_name: "editor".to_string(),
             pane_id: "%1".to_string(),
         }];
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -12,6 +12,8 @@ pub struct TmuxSession {
 #[derive(Clone, Debug)]
 pub struct TmuxPane {
     pub session_name: String,
+    pub window_id: String,
+    pub window_name: String,
     pub pane_id: String,
 }
 
@@ -51,7 +53,12 @@ pub fn list_sessions() -> Result<Vec<TmuxSession>, io::Error> {
 
 pub fn list_panes() -> Result<Vec<TmuxPane>, io::Error> {
     let output = Command::new("tmux")
-        .args(["list-panes", "-a", "-F", "#{session_name}\t#{pane_id}"])
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}",
+        ])
         .output()?;
     if !output.status.success() {
         let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -63,15 +70,23 @@ pub fn list_panes() -> Result<Vec<TmuxPane>, io::Error> {
     let panes: Vec<TmuxPane> = raw_output
         .lines()
         .filter_map(|line| {
-            let mut parts = line.splitn(2, '\t');
+            let mut parts = line.splitn(4, '\t');
             let session_name = parts.next()?.trim();
+            let window_id = parts.next()?.trim();
+            let window_name = parts.next()?.trim();
             let pane_id = parts.next()?.trim();
-            if session_name.is_empty() || pane_id.is_empty() {
+            if session_name.is_empty()
+                || window_id.is_empty()
+                || window_name.is_empty()
+                || pane_id.is_empty()
+            {
                 debug!("skipping invalid pane line: {}", line);
                 None
             } else {
                 let pane = TmuxPane {
                     session_name: session_name.to_string(),
+                    window_id: window_id.to_string(),
+                    window_name: window_name.to_string(),
                     pane_id: pane_id.to_string(),
                 };
                 debug!("parsed pane: {:?}", pane);
@@ -197,14 +212,21 @@ esac
     fn list_panes_parses_output() {
         let mut env = EnvGuard::new("tmux-list-panes");
         setup_fake_tmux(&mut env);
-        env.set_var("TMUX_LIST_PANES", "alpha\t%1\nbeta\t%2\n");
+        env.set_var(
+            "TMUX_LIST_PANES",
+            "alpha\t@10\teditor\t%1\nbeta\t@20\tserver\t%2\n",
+        );
         env.remove_var("TMUX_LIST_PANES_EXIT");
 
         let panes = list_panes().expect("list panes");
         assert_eq!(panes.len(), 2);
         assert_eq!(panes[0].session_name, "alpha");
+        assert_eq!(panes[0].window_id, "@10");
+        assert_eq!(panes[0].window_name, "editor");
         assert_eq!(panes[0].pane_id, "%1");
         assert_eq!(panes[1].session_name, "beta");
+        assert_eq!(panes[1].window_id, "@20");
+        assert_eq!(panes[1].window_name, "server");
         assert_eq!(panes[1].pane_id, "%2");
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -80,8 +80,24 @@ struct SessionRow {
     status: Option<crate::context::AgentStatus>,
     /// The context of the session
     context: String,
-    /// The panes belonging to the session
+    /// The windows belonging to the session
+    windows: Vec<WindowRow>,
+}
+
+#[derive(Clone)]
+struct WindowRow {
+    /// The tmux window ID
+    id: String,
+    /// The tmux window name
+    name: String,
+    /// The status of the window
+    status: Option<crate::context::AgentStatus>,
+    /// The context of the window
+    context: String,
+    /// The panes belonging to the window
     panes: Vec<PaneRow>,
+    /// The session ID
+    session_id: String,
 }
 
 #[derive(Clone)]
@@ -101,19 +117,31 @@ struct PaneRow {
 #[derive(Clone)]
 enum RowItem {
     Session(SessionRow),
+    Window(WindowRow),
     Pane(PaneRow),
 }
 
 #[derive(Clone, PartialEq, Eq)]
 enum RowKey {
     Session(String),
-    Pane { session_id: String, pane_id: String },
+    Window {
+        session_id: String,
+        window_id: String,
+    },
+    Pane {
+        session_id: String,
+        pane_id: String,
+    },
 }
 
 impl RowItem {
     fn key(&self) -> RowKey {
         match self {
             RowItem::Session(row) => RowKey::Session(row.id.clone()),
+            RowItem::Window(row) => RowKey::Window {
+                session_id: row.session_id.clone(),
+                window_id: row.id.clone(),
+            },
             RowItem::Pane(row) => RowKey::Pane {
                 session_id: row.session_id.clone(),
                 pane_id: row.id.clone(),
@@ -138,7 +166,6 @@ struct SearchQuery {
 struct ColumnWidths {
     session: u16,
     status: u16,
-    context: u16,
 }
 
 type FilterFn = Box<dyn Fn(&str, &[String]) -> Result<String, TuiError>>;
@@ -172,7 +199,6 @@ impl App {
             widths: ColumnWidths {
                 session: 0,
                 status: 0,
-                context: 0,
             },
             search: SearchQuery {
                 query: String::new(),
@@ -367,8 +393,11 @@ impl App {
         for session in &self.filtered_sessions {
             rows.push(RowItem::Session(session.clone()));
             if self.expanded_sessions.contains(&session.id) {
-                for pane in &session.panes {
-                    rows.push(RowItem::Pane(pane.clone()));
+                for window in &session.windows {
+                    rows.push(RowItem::Window(window.clone()));
+                    for pane in &window.panes {
+                        rows.push(RowItem::Pane(pane.clone()));
+                    }
                 }
             }
         }
@@ -395,6 +424,7 @@ impl App {
         if let Some(row) = self.selected_row() {
             let target_session_id = match row {
                 RowItem::Session(session) => session.id.as_str(),
+                RowItem::Window(window) => window.session_id.as_str(),
                 RowItem::Pane(pane) => pane.session_id.as_str(),
             };
             info!("tui switching to session_id={}", target_session_id);
@@ -408,6 +438,7 @@ impl App {
         let previous = self.selected_key();
         let session_id = self.selected_row().map(|row| match row {
             RowItem::Session(session) => session.id.clone(),
+            RowItem::Window(window) => window.session_id.clone(),
             RowItem::Pane(pane) => pane.session_id.clone(),
         });
         if let Some(session_id) = session_id {
@@ -421,6 +452,7 @@ impl App {
         let previous = self.selected_key();
         let session_id = self.selected_row().map(|row| match row {
             RowItem::Session(session) => session.id.clone(),
+            RowItem::Window(window) => window.session_id.clone(),
             RowItem::Pane(pane) => pane.session_id.clone(),
         });
         if let Some(session_id) = session_id {
@@ -562,7 +594,8 @@ impl App {
                 .get(&row.id)
                 .map(|index| format!("{}: {}", session_shortcut_label(*index), row.name))
                 .unwrap_or_else(|| row.name.clone()),
-            RowItem::Pane(row) => format!("  └─ {}", pane_label(row)),
+            RowItem::Window(row) => format!("  ◦ {}", row.name),
+            RowItem::Pane(row) => format!("    └─ {}", pane_label(row)),
         }
     }
 
@@ -581,19 +614,10 @@ impl App {
             .max()
             .unwrap_or(0)
             .max(UnicodeWidthStr::width("Status"));
-        let context = self
-            .rows
-            .iter()
-            .map(|item| UnicodeWidthStr::width(row_context(item).as_str()))
-            .max()
-            .unwrap_or(0)
-            .max(UnicodeWidthStr::width("Context"));
-
         #[allow(clippy::cast_possible_truncation)]
         ColumnWidths {
             session: session as u16,
             status: status as u16,
-            context: context as u16,
         }
     }
 
@@ -623,7 +647,7 @@ impl App {
         };
         if let Some(row_index) = self.rows.iter().position(|row| match row {
             RowItem::Session(row) => row.id == session.id,
-            RowItem::Pane(_) => false,
+            RowItem::Window(_) | RowItem::Pane(_) => false,
         }) {
             self.state.select(Some(row_index));
         }
@@ -692,6 +716,8 @@ impl PaneSelector {
                             crate::context::upsert_pane(
                                 session_name,
                                 &self.pane_id,
+                                None,
+                                None,
                                 None,
                                 status,
                                 None,
@@ -824,11 +850,15 @@ fn build_sessions(
         contexts.keys().collect::<Vec<_>>()
     );
 
-    let mut panes_by_session: HashMap<String, Vec<String>> = HashMap::new();
+    let mut panes_by_session_window: HashMap<String, HashMap<String, (String, Vec<String>)>> =
+        HashMap::new();
     for pane in panes {
-        panes_by_session
+        panes_by_session_window
             .entry(pane.session_name)
             .or_default()
+            .entry(pane.window_id)
+            .or_insert_with(|| (pane.window_name, Vec::new()))
+            .1
             .push(pane.pane_id);
     }
 
@@ -836,57 +866,83 @@ fn build_sessions(
         .into_iter()
         .map(|session| {
             let key = crate::context::session_key(&session.name);
-            debug!("building session: {:?} computed_key={}", session, key);
-
             let context = contexts.get(&key);
-            if let Some(ctx) = context {
-                debug!("  ✓ context found: {:?}", ctx);
-            } else {
-                debug!("  ✗ no context found for session={}", session.name);
-            }
 
             let context_value =
                 normalize_field(context.and_then(|ctx| ctx.session_context.as_ref()));
             let override_status = context.and_then(|ctx| ctx.session_status.clone());
 
-            let mut pane_rows = panes_by_session
-                .get(&session.name)
-                .cloned()
-                .unwrap_or_default();
-            pane_rows.sort();
-            let panes: Vec<PaneRow> = pane_rows
+            let mut window_rows = panes_by_session_window
+                .remove(&session.name)
+                .unwrap_or_default()
                 .into_iter()
-                .map(|pane_id| {
-                    let pane_ctx = context.and_then(|ctx| ctx.panes.get(&pane_id));
-                    let pane_alias = pane_ctx.and_then(|pane| {
-                        pane.pane_name
-                            .as_ref()
-                            .map(|name| name.trim())
-                            .filter(|name| !name.is_empty())
-                            .map(str::to_string)
-                    });
-                    let pane_status = pane_ctx.and_then(|pane| pane.pane_status.clone());
-                    let pane_context_value =
-                        normalize_field(pane_ctx.and_then(|pane| pane.pane_context.as_ref()));
-                    PaneRow {
-                        id: pane_id,
-                        alias: pane_alias,
-                        status: pane_status,
-                        context: pane_context_value,
+                .collect::<Vec<_>>();
+            window_rows.sort_by(|(left_id, _), (right_id, _)| left_id.cmp(right_id));
+
+            let windows: Vec<WindowRow> = window_rows
+                .into_iter()
+                .map(|(window_id, (window_live_name, mut pane_rows))| {
+                    pane_rows.sort();
+                    let window_ctx = context.and_then(|ctx| ctx.windows.get(&window_id));
+                    let window_name = window_ctx
+                        .and_then(|window| window.window_name.as_ref())
+                        .map(|name| name.to_string())
+                        .unwrap_or(window_live_name);
+                    let window_context = normalize_field(
+                        window_ctx.and_then(|window| window.window_context.as_ref()),
+                    );
+                    let window_status = window_ctx.and_then(|window| window.window_status.clone());
+
+                    let panes: Vec<PaneRow> = pane_rows
+                        .into_iter()
+                        .map(|pane_id| {
+                            let pane_ctx = context.and_then(|ctx| ctx.panes.get(&pane_id));
+                            let pane_alias = pane_ctx.and_then(|pane| {
+                                pane.pane_name
+                                    .as_ref()
+                                    .map(|name| name.trim())
+                                    .filter(|name| !name.is_empty())
+                                    .map(|name| name.to_string())
+                            });
+                            let pane_status = pane_ctx.and_then(|pane| pane.pane_status.clone());
+                            let pane_context_value = normalize_field(
+                                pane_ctx.and_then(|pane| pane.pane_context.as_ref()),
+                            );
+                            PaneRow {
+                                id: pane_id,
+                                alias: pane_alias,
+                                status: pane_status,
+                                context: pane_context_value,
+                                session_id: session.id.clone(),
+                            }
+                        })
+                        .collect();
+                    let status = crate::context::effective_session_status(
+                        window_status,
+                        panes.iter().map(|pane| pane.status.clone()),
+                    );
+
+                    WindowRow {
+                        id: window_id,
+                        name: window_name,
+                        status,
+                        context: window_context,
+                        panes,
                         session_id: session.id.clone(),
                     }
                 })
                 .collect();
+
             let status = crate::context::effective_session_status(
                 override_status,
-                panes.iter().map(|pane| pane.status.clone()),
+                windows.iter().map(|window| window.status.clone()),
             );
             SessionRow {
                 id: session.id,
                 name: session.name,
                 status,
                 context: context_value,
-                panes,
+                windows,
             }
         })
         .collect();
@@ -894,7 +950,7 @@ fn build_sessions(
         "built {} session rows from {} contexts and {} pane groups",
         built.len(),
         contexts.len(),
-        panes_by_session.len()
+        panes_by_session_window.len()
     );
     built
 }
@@ -912,6 +968,7 @@ fn collect_live_panes(panes: &[crate::tmux::TmuxPane]) -> HashMap<String, HashSe
 fn row_status(item: &RowItem) -> Option<&crate::context::AgentStatus> {
     match item {
         RowItem::Session(row) => row.status.as_ref(),
+        RowItem::Window(row) => row.status.as_ref(),
         RowItem::Pane(row) => row.status.as_ref(),
     }
 }
@@ -919,6 +976,7 @@ fn row_status(item: &RowItem) -> Option<&crate::context::AgentStatus> {
 fn row_context(item: &RowItem) -> String {
     match item {
         RowItem::Session(row) => row.context.clone(),
+        RowItem::Window(row) => row.context.clone(),
         RowItem::Pane(row) => row.context.clone(),
     }
 }
@@ -955,7 +1013,7 @@ fn normalize_field(value: Option<&String>) -> String {
     value
         .map(|value| value.trim())
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .map(|name| name.to_string())
         .unwrap_or_else(|| DATA_NOT_RECEIVED.to_string())
 }
 
@@ -997,7 +1055,7 @@ fn status_style(status: Option<&crate::context::AgentStatus>) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{AgentStatus, PaneContext, SessionContext, session_key};
+    use crate::context::{AgentStatus, PaneContext, SessionContext, WindowContext, session_key};
     use crate::tmux::{TmuxPane, TmuxSession};
     use std::collections::HashMap;
 
@@ -1007,7 +1065,7 @@ mod tests {
             name: name.to_string(),
             status: None,
             context: "ctx".to_string(),
-            panes: Vec::new(),
+            windows: Vec::new(),
         }
     }
 
@@ -1040,14 +1098,20 @@ mod tests {
         let panes = vec![
             TmuxPane {
                 session_name: "alpha".to_string(),
+                window_id: "@10".to_string(),
+                window_name: "editor".to_string(),
                 pane_id: "%1".to_string(),
             },
             TmuxPane {
                 session_name: "alpha".to_string(),
+                window_id: "@10".to_string(),
+                window_name: "editor".to_string(),
                 pane_id: "%2".to_string(),
             },
             TmuxPane {
                 session_name: "beta".to_string(),
+                window_id: "@20".to_string(),
+                window_name: "server".to_string(),
                 pane_id: "%3".to_string(),
             },
         ];
@@ -1075,6 +1139,8 @@ mod tests {
             "%2".to_string(),
             PaneContext {
                 pane_id: None,
+                window_id: Some("@10".to_string()),
+                window_name: Some("editor".to_string()),
                 pane_name: Some("pane-two".to_string()),
                 pane_status: Some(AgentStatus::Done),
                 pane_context: Some("pctx".to_string()),
@@ -1089,6 +1155,15 @@ mod tests {
                 session_id: None,
                 session_status: Some(AgentStatus::Working),
                 session_context: Some("ctx".to_string()),
+                windows: HashMap::from([(
+                    "@10".to_string(),
+                    WindowContext {
+                        window_id: Some("@10".to_string()),
+                        window_name: Some("editor".to_string()),
+                        window_status: None,
+                        window_context: None,
+                    },
+                )]),
                 panes: pane_map,
             },
         );
@@ -1096,10 +1171,14 @@ mod tests {
         let panes = vec![
             TmuxPane {
                 session_name: "alpha".to_string(),
+                window_id: "@10".to_string(),
+                window_name: "editor".to_string(),
                 pane_id: "%2".to_string(),
             },
             TmuxPane {
                 session_name: "alpha".to_string(),
+                window_id: "@10".to_string(),
+                window_name: "editor".to_string(),
                 pane_id: "%1".to_string(),
             },
         ];
@@ -1111,13 +1190,15 @@ mod tests {
             .expect("alpha row");
         assert_eq!(alpha.status, Some(AgentStatus::Working));
         assert_eq!(alpha.context, "ctx");
-        assert_eq!(alpha.panes.len(), 2);
-        assert_eq!(alpha.panes[0].id, "%1");
-        assert_eq!(alpha.panes[0].context, DATA_NOT_RECEIVED);
-        assert_eq!(alpha.panes[1].id, "%2");
-        assert_eq!(alpha.panes[1].alias.as_deref(), Some("pane-two"));
-        assert_eq!(alpha.panes[1].status, Some(AgentStatus::Done));
-        assert_eq!(alpha.panes[1].context, "pctx");
+        assert_eq!(alpha.windows.len(), 1);
+        assert_eq!(alpha.windows[0].name, "editor");
+        assert_eq!(alpha.windows[0].panes.len(), 2);
+        assert_eq!(alpha.windows[0].panes[0].id, "%1");
+        assert_eq!(alpha.windows[0].panes[0].context, DATA_NOT_RECEIVED);
+        assert_eq!(alpha.windows[0].panes[1].id, "%2");
+        assert_eq!(alpha.windows[0].panes[1].alias.as_deref(), Some("pane-two"));
+        assert_eq!(alpha.windows[0].panes[1].status, Some(AgentStatus::Done));
+        assert_eq!(alpha.windows[0].panes[1].context, "pctx");
     }
 
     #[test]
@@ -1171,11 +1252,18 @@ mod tests {
             name: "alpha".to_string(),
             status: None,
             context: "ctx".to_string(),
-            panes: vec![PaneRow {
-                id: "%1".to_string(),
-                alias: Some("verylongalias".to_string()),
+            windows: vec![WindowRow {
+                id: "@10".to_string(),
+                name: "editor".to_string(),
                 status: None,
-                context: "p1".to_string(),
+                context: "wctx".to_string(),
+                panes: vec![PaneRow {
+                    id: "%1".to_string(),
+                    alias: Some("verylongalias".to_string()),
+                    status: None,
+                    context: "p1".to_string(),
+                    session_id: "@1".to_string(),
+                }],
                 session_id: "@1".to_string(),
             }],
         }];
@@ -1185,7 +1273,7 @@ mod tests {
         app.expanded_sessions.insert("@1".to_string());
         app.rebuild_rows();
 
-        assert_eq!(app.row_label(&app.rows[1]), "  └─ verylon...");
+        assert_eq!(app.row_label(&app.rows[2]), "    └─ verylon...");
     }
 
     #[test]
@@ -1196,22 +1284,29 @@ mod tests {
                 name: "alpha".to_string(),
                 status: None,
                 context: "ctx".to_string(),
-                panes: vec![
-                    PaneRow {
-                        id: "%1".to_string(),
-                        alias: None,
-                        status: None,
-                        context: "p1".to_string(),
-                        session_id: "@1".to_string(),
-                    },
-                    PaneRow {
-                        id: "%2".to_string(),
-                        alias: None,
-                        status: None,
-                        context: "p2".to_string(),
-                        session_id: "@1".to_string(),
-                    },
-                ],
+                windows: vec![WindowRow {
+                    id: "@10".to_string(),
+                    name: "editor".to_string(),
+                    status: None,
+                    context: "wctx".to_string(),
+                    panes: vec![
+                        PaneRow {
+                            id: "%1".to_string(),
+                            alias: None,
+                            status: None,
+                            context: "p1".to_string(),
+                            session_id: "@1".to_string(),
+                        },
+                        PaneRow {
+                            id: "%2".to_string(),
+                            alias: None,
+                            status: None,
+                            context: "p2".to_string(),
+                            session_id: "@1".to_string(),
+                        },
+                    ],
+                    session_id: "@1".to_string(),
+                }],
             },
             session_row("@2", "beta"),
         ];
@@ -1225,7 +1320,7 @@ mod tests {
         let selected = app.selected_row().expect("selected row");
         match selected {
             RowItem::Session(row) => assert_eq!(row.id, "@2"),
-            RowItem::Pane(_) => panic!("expected session row"),
+            RowItem::Window(_) | RowItem::Pane(_) => panic!("expected session row"),
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Persist tmux window metadata alongside panes so window-level info can be stored and surfaced in the UI and sync operations.
- Expose window identifiers in the CLI upsert flow so callers can annotate panes with the window they belong to.
- Present sessions → windows → panes hierarchically in the TUI for clearer navigation and display.
- Provide Fig completions for the new window flags to improve CLI ergonomics.

### Description
- Add CLI flags `--window-id` and `--window-name` to `UpsertArgs` and forward them from `handle_upsert` into `context::upsert_pane` so pane upserts can record window metadata.
- Extend data model in `src/context.rs` with `WindowContext` and add `window_id`/`window_name` fields to `PaneContext`, and track windows in `SessionContext`; update `upsert_pane`, `sync_with_tmux`, `prune_panes`, and `merge_context` to retain and reconcile windows and pane→window mappings.
- Update `src/tmux.rs` `list_panes` format to include `window_id` and `window_name` and parse them into `TmuxPane` entries so live state contains window info.
- Refactor `src/tui.rs` to a hierarchical view with `WindowRow` and nested `PaneRow`, adjust row keys/labels/measurements/navigation, and populate windows from tmux/context data for session-expanded displays.
- Update `README.md` to reflect new JSON shape and `jkl upsert` usage including `--window-id`/`--window-name` flags and sample JSON snippet.
- Add Fig completion generators `windowIdGenerator` and `windowNameGenerator` in `completions/fig/jkl.ts` and wire `--window-id`/`--window-name` into the `jkl upsert` completions.

### Testing
- Ran the full test suite with `cargo test --locked`, which completed successfully with all tests passing (46 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d39a7a0e883329e018b37e5b7ebe3)