### PR TITLE
feat: add musl and AL2 target-aware install/update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,17 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use_zigbuild: false
           - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu.2.26
+            rust_target: x86_64-unknown-linux-gnu
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            use_zigbuild: true
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-musl
             use_zigbuild: true
 
     steps:
@@ -32,7 +42,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_target || matrix.target }}
 
       - name: Install zig
         if: matrix.use_zigbuild == true

--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -34,8 +34,21 @@ jobs:
             asset: jkl-x86_64-unknown-linux-gnu.tar.gz
             use_zigbuild: false
           - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu.2.26
+            rust_target: x86_64-unknown-linux-gnu
+            asset: jkl-x86_64-unknown-linux-gnu-al2.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            asset: jkl-x86_64-unknown-linux-musl.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             asset: jkl-aarch64-unknown-linux-gnu.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-musl
+            asset: jkl-aarch64-unknown-linux-musl.tar.gz
             use_zigbuild: true
 
     steps:
@@ -45,7 +58,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_target || matrix.target }}
 
       - name: Install zig
         if: matrix.use_zigbuild == true
@@ -118,4 +131,7 @@ jobs:
             dist/jkl-x86_64-apple-darwin.tar.gz
             dist/jkl-aarch64-apple-darwin.tar.gz
             dist/jkl-x86_64-unknown-linux-gnu.tar.gz
+            dist/jkl-x86_64-unknown-linux-gnu-al2.tar.gz
             dist/jkl-aarch64-unknown-linux-gnu.tar.gz
+            dist/jkl-x86_64-unknown-linux-musl.tar.gz
+            dist/jkl-aarch64-unknown-linux-musl.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,21 @@ jobs:
             asset: jkl-x86_64-unknown-linux-gnu.tar.gz
             use_zigbuild: false
           - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu.2.26
+            rust_target: x86_64-unknown-linux-gnu
+            asset: jkl-x86_64-unknown-linux-gnu-al2.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            asset: jkl-x86_64-unknown-linux-musl.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             asset: jkl-aarch64-unknown-linux-gnu.tar.gz
+            use_zigbuild: true
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-musl
+            asset: jkl-aarch64-unknown-linux-musl.tar.gz
             use_zigbuild: true
 
     steps:
@@ -44,7 +57,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_target || matrix.target }}
 
       - name: Install zig
         if: matrix.use_zigbuild == true
@@ -102,4 +115,7 @@ jobs:
             dist/jkl-x86_64-apple-darwin.tar.gz
             dist/jkl-aarch64-apple-darwin.tar.gz
             dist/jkl-x86_64-unknown-linux-gnu.tar.gz
+            dist/jkl-x86_64-unknown-linux-gnu-al2.tar.gz
             dist/jkl-aarch64-unknown-linux-gnu.tar.gz
+            dist/jkl-x86_64-unknown-linux-musl.tar.gz
+            dist/jkl-aarch64-unknown-linux-musl.tar.gz

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/install.sh | 
 ```
 
 Optional: set `JKL_INSTALL_DIR` to choose where binaries/scripts are installed.
+On Linux, the installer picks:
+
+- `*-unknown-linux-musl` on Alpine
+- `x86_64-unknown-linux-gnu-al2` on Amazon Linux 2
+- `*-unknown-linux-gnu` otherwise
 
 The installer adds:
 
@@ -32,6 +37,25 @@ To force this in non-interactive installs, set:
 
 - `JKL_INSTALL_FIG_COMPLETIONS=1` to install
 - `JKL_INSTALL_FIG_COMPLETIONS=0` to skip
+
+### Release Asset (manual)
+
+Use install overrides instead of downloading/extracting assets manually.
+
+```bash
+# specific release tag:
+JKL_INSTALL_TAG=v0.2.0 curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/install.sh | bash
+
+# specific target (example: musl):
+JKL_INSTALL_TARGET=x86_64-unknown-linux-musl curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/install.sh | bash
+
+# both:
+JKL_INSTALL_TAG=v0.2.0-rc.1 JKL_INSTALL_TARGET=aarch64-unknown-linux-gnu curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/install.sh | bash
+```
+
+Optional override:
+
+- `JKL_INSTALL_ASSET_SUFFIX=-al2` to force an asset suffix (normally auto-detected on Amazon Linux 2)
 
 ### Cargo
 
@@ -66,6 +90,7 @@ jkl-sync-fig-autocomplete
 
 Master pre-releases are selected from tags that include `-rc.` (for example, `v0.2.0-rc.1`).
 Dev previews are selected from tags that include `-dev.` (for example, `v0.2.0-dev.42.abc1234`).
+`jkl update` keeps the installed binary target (for example, a `*-unknown-linux-musl` install updates to `*-unknown-linux-musl` assets). On Amazon Linux 2, `jkl update` automatically selects `-al2` release assets.
 
 If you installed via Cargo:
 
@@ -100,7 +125,10 @@ The update command and install script expect GitHub release assets named:
 - `jkl-x86_64-apple-darwin.tar.gz`
 - `jkl-aarch64-apple-darwin.tar.gz`
 - `jkl-x86_64-unknown-linux-gnu.tar.gz`
+- `jkl-x86_64-unknown-linux-gnu-al2.tar.gz`
 - `jkl-aarch64-unknown-linux-gnu.tar.gz`
+- `jkl-x86_64-unknown-linux-musl.tar.gz`
+- `jkl-aarch64-unknown-linux-musl.tar.gz`
 
 Each archive should contain the `jkl` binary at the top level.
 

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ BIN_NAME="jkl"
 REPO="cruzluna/jkl-2"
 SYNC_SCRIPT_NAME="jkl-sync-fig-autocomplete"
 INSTALL_DIR="${JKL_INSTALL_DIR:-$HOME/.local/bin}"
+INSTALL_TAG="${JKL_INSTALL_TAG:-latest}"
 
 should_install_fig_helper() {
   case "${JKL_INSTALL_FIG_COMPLETIONS:-}" in
@@ -33,12 +34,33 @@ should_install_fig_helper() {
   return 1
 }
 
+is_amazon_linux_2() {
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    if [[ "${ID:-}" == "amzn" && ( "${VERSION_ID:-}" == "2" || "${VERSION_ID:-}" == 2.* ) ]]; then
+      return 0
+    fi
+  fi
+
+  if [[ -r /etc/system-release ]] && grep -qi "Amazon Linux release 2" /etc/system-release; then
+    return 0
+  fi
+
+  return 1
+}
+
 uname_s="$(uname -s)"
 uname_m="$(uname -m)"
 
 case "$uname_s" in
   Darwin) os="apple-darwin" ;;
-  Linux) os="unknown-linux-gnu" ;;
+  Linux)
+    os="unknown-linux-gnu"
+    if [[ -f /etc/alpine-release ]]; then
+      os="unknown-linux-musl"
+    fi
+    ;;
   *)
     echo "Unsupported OS: $uname_s" >&2
     exit 1
@@ -54,9 +76,31 @@ case "$uname_m" in
     ;;
 esac
 
+asset_suffix=""
 target="${arch}-${os}"
-archive="${BIN_NAME}-${target}.tar.gz"
-url="https://github.com/${REPO}/releases/latest/download/${archive}"
+if [[ -n "${JKL_INSTALL_TARGET:-}" ]]; then
+  target="${JKL_INSTALL_TARGET}"
+fi
+
+if [[ "$target" == *"-al2" ]]; then
+  target="${target%-al2}"
+  if [[ -z "${JKL_INSTALL_ASSET_SUFFIX:-}" ]]; then
+    asset_suffix="-al2"
+  fi
+fi
+
+if [[ -n "${JKL_INSTALL_ASSET_SUFFIX:-}" ]]; then
+  asset_suffix="${JKL_INSTALL_ASSET_SUFFIX}"
+elif [[ "$target" == *"-unknown-linux-gnu" ]] && is_amazon_linux_2; then
+  asset_suffix="-al2"
+fi
+
+archive="${BIN_NAME}-${target}${asset_suffix}.tar.gz"
+if [[ "$INSTALL_TAG" == "latest" ]]; then
+  url="https://github.com/${REPO}/releases/latest/download/${archive}"
+else
+  url="https://github.com/${REPO}/releases/download/${INSTALL_TAG}/${archive}"
+fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use self_update::backends::github::ReleaseList;
-use self_update::update::Release;
+use self_update::update::{Release, ReleaseAsset};
+use std::fs;
 use std::path::PathBuf;
 
 const REPO_OWNER: &str = "cruzluna";
@@ -55,36 +56,67 @@ fn update_config() -> UpdateConfig {
     }
 }
 
-fn target_triple(os: &str, arch: &str) -> Result<&'static str> {
-    let os_part = match os {
-        "macos" => "apple-darwin",
-        "linux" => "unknown-linux-gnu",
-        other => bail!("unsupported os: {other}"),
-    };
-
-    let arch_part = match arch {
-        "x86_64" => "x86_64",
-        "aarch64" => "aarch64",
-        other => bail!("unsupported arch: {other}"),
-    };
-
-    Ok(match (arch_part, os_part) {
-        ("x86_64", "apple-darwin") => "x86_64-apple-darwin",
-        ("aarch64", "apple-darwin") => "aarch64-apple-darwin",
-        ("x86_64", "unknown-linux-gnu") => "x86_64-unknown-linux-gnu",
-        ("aarch64", "unknown-linux-gnu") => "aarch64-unknown-linux-gnu",
-        _ => bail!("unsupported target combo: {arch_part}-{os_part}"),
-    })
+fn detect_target() -> String {
+    self_update::get_target().to_string()
 }
 
-fn detect_target() -> Result<String> {
-    let os = std::env::consts::OS;
-    let arch = std::env::consts::ARCH;
-    Ok(target_triple(os, arch)?.to_string())
+fn archive_name(target: &str, identifier: Option<&str>) -> String {
+    match identifier {
+        Some(identifier) => format!("{BIN_NAME}-{target}-{identifier}.tar.gz"),
+        None => format!("{BIN_NAME}-{target}.tar.gz"),
+    }
 }
 
-fn archive_name(target: &str) -> String {
-    format!("{BIN_NAME}-{target}.tar.gz")
+fn parse_os_release_value(contents: &str, key: &str) -> Option<String> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((line_key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        if line_key != key {
+            continue;
+        }
+        return Some(raw_value.trim().trim_matches('"').to_string());
+    }
+    None
+}
+
+fn is_amazon_linux_2_from_os_release(contents: &str) -> bool {
+    let id = parse_os_release_value(contents, "ID");
+    let version_id = parse_os_release_value(contents, "VERSION_ID");
+    matches!(id.as_deref(), Some("amzn"))
+        && version_id
+            .as_deref()
+            .is_some_and(|version| version == "2" || version.starts_with("2."))
+}
+
+fn is_amazon_linux_2() -> bool {
+    if let Ok(os_release) = fs::read_to_string("/etc/os-release") {
+        if is_amazon_linux_2_from_os_release(&os_release) {
+            return true;
+        }
+    }
+
+    if let Ok(system_release) = fs::read_to_string("/etc/system-release") {
+        let lower = system_release.to_ascii_lowercase();
+        return lower.contains("amazon linux") && lower.contains("release 2");
+    }
+
+    false
+}
+
+fn detect_asset_identifier_for(target: &str, amazon_linux_2: bool) -> Option<&'static str> {
+    if amazon_linux_2 && target.ends_with("unknown-linux-gnu") {
+        return Some("al2");
+    }
+    None
+}
+
+fn detect_asset_identifier(target: &str) -> Option<&'static str> {
+    detect_asset_identifier_for(target, is_amazon_linux_2())
 }
 
 fn select_channel_tag(releases: &[Release], channel: UpdateChannel) -> Option<String> {
@@ -95,9 +127,24 @@ fn select_channel_tag(releases: &[Release], channel: UpdateChannel) -> Option<St
         .map(|release| format!("v{}", release.version))
 }
 
+fn filter_releases_for_identifier(
+    releases: Vec<Release>,
+    target: Option<&str>,
+    identifier: Option<&str>,
+) -> Vec<Release> {
+    if let (Some(target), Some(identifier)) = (target, identifier) {
+        return releases
+            .into_iter()
+            .filter(|release| release.asset_for(target, Some(identifier)).is_some())
+            .collect();
+    }
+    releases
+}
+
 fn find_channel_tag(
     config: &UpdateConfig,
     target: Option<&str>,
+    identifier: Option<&str>,
     channel: UpdateChannel,
 ) -> Result<String> {
     if channel == UpdateChannel::Stable {
@@ -111,7 +158,7 @@ fn find_channel_tag(
     if let Some(target) = target {
         builder.with_target(target);
     }
-    let releases = builder.build()?.fetch()?;
+    let releases = filter_releases_for_identifier(builder.build()?.fetch()?, target, identifier);
     select_channel_tag(&releases, channel).ok_or_else(|| anyhow::anyhow!(channel.not_found_error()))
 }
 
@@ -128,25 +175,37 @@ fn command_in_path(command: &str) -> bool {
 pub fn run(channel: UpdateChannel) -> Result<()> {
     let config = update_config();
     let current_version = self_update::cargo_crate_version!();
-    let target = detect_target().ok();
+    let target = detect_target();
+    let asset_identifier = detect_asset_identifier(&target);
     let mut builder = self_update::backends::github::Update::configure();
     builder
         .repo_owner(config.repo_owner)
         .repo_name(config.repo_name)
         .bin_name(config.bin_name)
         .show_download_progress(true)
-        .current_version(current_version);
+        .current_version(current_version)
+        .target(&target);
+    if let Some(identifier) = asset_identifier {
+        builder.identifier(identifier);
+    }
 
-    if let Some(target) = target.as_deref() {
+    if let Some(identifier) = asset_identifier {
+        log::info!(
+            "self-update target={} identifier={} expected_asset={}",
+            target,
+            identifier,
+            archive_name(&target, Some(identifier))
+        );
+    } else {
         log::info!(
             "self-update target={} expected_asset={}",
             target,
-            archive_name(target)
+            archive_name(&target, None)
         );
     }
 
     if channel != UpdateChannel::Stable {
-        let tag = find_channel_tag(&config, target.as_deref(), channel)
+        let tag = find_channel_tag(&config, Some(target.as_str()), asset_identifier, channel)
             .with_context(|| format!("find {} tag", channel.context_label()))?;
         builder.target_version_tag(&tag);
     }
@@ -188,6 +247,22 @@ mod tests {
         }
     }
 
+    fn release_with_assets(version: &str, asset_names: &[&str]) -> Release {
+        Release {
+            name: version.to_string(),
+            version: version.to_string(),
+            date: "2025-01-01T00:00:00Z".to_string(),
+            body: None,
+            assets: asset_names
+                .iter()
+                .map(|name| ReleaseAsset {
+                    download_url: format!("https://example.com/{name}"),
+                    name: (*name).to_string(),
+                })
+                .collect(),
+        }
+    }
+
     #[test]
     fn update_config_sets_repo_fields() {
         let config = update_config();
@@ -197,33 +272,122 @@ mod tests {
     }
 
     #[test]
-    fn target_triple_maps_macos_x86_64() {
-        let target = target_triple("macos", "x86_64").expect("target");
-        assert_eq!(target, "x86_64-apple-darwin");
-    }
-
-    #[test]
-    fn target_triple_maps_linux_aarch64() {
-        let target = target_triple("linux", "aarch64").expect("target");
-        assert_eq!(target, "aarch64-unknown-linux-gnu");
-    }
-
-    #[test]
-    fn target_triple_rejects_unknown_os() {
-        let err = target_triple("windows", "x86_64").expect_err("expected error");
-        assert!(err.to_string().contains("unsupported os"));
-    }
-
-    #[test]
-    fn target_triple_rejects_unknown_arch() {
-        let err = target_triple("linux", "mips").expect_err("expected error");
-        assert!(err.to_string().contains("unsupported arch"));
+    fn detect_target_matches_self_update_target() {
+        assert_eq!(detect_target(), self_update::get_target());
     }
 
     #[test]
     fn archive_name_uses_bin_and_target() {
-        let name = archive_name("x86_64-unknown-linux-gnu");
+        let name = archive_name("x86_64-unknown-linux-gnu", None);
         assert_eq!(name, "jkl-x86_64-unknown-linux-gnu.tar.gz");
+    }
+
+    #[test]
+    fn archive_name_includes_identifier() {
+        let name = archive_name("x86_64-unknown-linux-gnu", Some("al2"));
+        assert_eq!(name, "jkl-x86_64-unknown-linux-gnu-al2.tar.gz");
+    }
+
+    #[test]
+    fn parse_os_release_value_reads_quoted_values() {
+        let os_release = r#"
+ID="amzn"
+VERSION_ID="2.0.20240101"
+"#;
+        assert_eq!(
+            parse_os_release_value(os_release, "ID").as_deref(),
+            Some("amzn")
+        );
+        assert_eq!(
+            parse_os_release_value(os_release, "VERSION_ID").as_deref(),
+            Some("2.0.20240101")
+        );
+    }
+
+    #[test]
+    fn parse_os_release_value_returns_none_when_key_missing() {
+        let os_release = "ID=ubuntu\nVERSION_ID=24.04\n";
+        assert_eq!(parse_os_release_value(os_release, "NAME"), None);
+    }
+
+    #[test]
+    fn is_amazon_linux_2_from_os_release_matches_amzn2() {
+        let os_release = r#"
+ID="amzn"
+VERSION_ID="2"
+"#;
+        assert!(is_amazon_linux_2_from_os_release(os_release));
+    }
+
+    #[test]
+    fn is_amazon_linux_2_from_os_release_matches_amzn2_patch() {
+        let os_release = r#"
+ID=amzn
+VERSION_ID=2.0.20240101
+"#;
+        assert!(is_amazon_linux_2_from_os_release(os_release));
+    }
+
+    #[test]
+    fn is_amazon_linux_2_from_os_release_rejects_other_versions() {
+        let os_release = r#"
+ID=amzn
+VERSION_ID=2023
+"#;
+        assert!(!is_amazon_linux_2_from_os_release(os_release));
+    }
+
+    #[test]
+    fn detect_asset_identifier_for_linux_gnu_on_amazon_linux_2() {
+        let identifier = detect_asset_identifier_for("x86_64-unknown-linux-gnu", true);
+        assert_eq!(identifier, Some("al2"));
+    }
+
+    #[test]
+    fn detect_asset_identifier_for_non_amazon_linux_2_or_non_gnu() {
+        assert_eq!(
+            detect_asset_identifier_for("x86_64-unknown-linux-gnu", false),
+            None
+        );
+        assert_eq!(
+            detect_asset_identifier_for("x86_64-unknown-linux-musl", true),
+            None
+        );
+    }
+
+    #[test]
+    fn filter_releases_for_identifier_keeps_only_matching_assets() {
+        let releases = vec![
+            release_with_assets("0.2.0-rc.1", &["jkl-x86_64-unknown-linux-gnu.tar.gz"]),
+            release_with_assets("0.2.0-rc.2", &["jkl-x86_64-unknown-linux-gnu-al2.tar.gz"]),
+        ];
+        let filtered =
+            filter_releases_for_identifier(releases, Some("x86_64-unknown-linux-gnu"), Some("al2"));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].version, "0.2.0-rc.2");
+    }
+
+    #[test]
+    fn filter_releases_for_identifier_is_noop_without_identifier() {
+        let releases = vec![
+            release_with_assets("0.2.0-rc.1", &["jkl-x86_64-unknown-linux-gnu.tar.gz"]),
+            release_with_assets("0.2.0-rc.2", &["jkl-x86_64-unknown-linux-gnu-al2.tar.gz"]),
+        ];
+        let filtered =
+            filter_releases_for_identifier(releases, Some("x86_64-unknown-linux-gnu"), None);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn select_channel_tag_with_identifier_filter_picks_matching_release() {
+        let releases = vec![
+            release_with_assets("0.2.0-rc.1", &["jkl-x86_64-unknown-linux-gnu.tar.gz"]),
+            release_with_assets("0.2.0-rc.2", &["jkl-x86_64-unknown-linux-gnu-al2.tar.gz"]),
+        ];
+        let filtered =
+            filter_releases_for_identifier(releases, Some("x86_64-unknown-linux-gnu"), Some("al2"));
+        let tag = select_channel_tag(&filtered, UpdateChannel::PreRelease);
+        assert_eq!(tag.as_deref(), Some("v0.2.0-rc.2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add musl Linux targets to CI/release/dev workflows and asset docs
- add an AL2-compatible Linux GNU asset and automatic AL2 selection in installer/update paths
- add installer overrides for release tag/target selection (JKL_INSTALL_TAG, JKL_INSTALL_TARGET, JKL_INSTALL_ASSET_SUFFIX)
- expand update unit tests for AL2 detection and identifier-based release filtering

## Testing
- cargo test --locked
- cargo test --locked update::tests
- bash -n install.sh