### PR TITLE
feat: add experimental init command and integration setup flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +795,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1103,6 +1118,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979f5ab9760427ada4fa5762b2d905e5b12704fb1fada07b6bfa66aeaa586f87"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1189,7 @@ dependencies = [
  "clap",
  "clap_mangen",
  "flexi_logger",
+ "inquire",
  "log",
  "ratatui",
  "self_update",
@@ -2359,6 +2389,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ anyhow = "1.0.100"
 flexi_logger = "0.31.8"
 log = "0.4.28"
 self_update = { version = "0.39.0", default-features = false, features = ["archive-tar", "compression-flate2", "rustls"] }
+inquire = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/install.sh | bash
 ```
 
-Optional: set `JKL_INSTALL_DIR` to choose where binaries/scripts are installed.
+Optional: set `JKL_INSTALL_DIR` to choose where binaries are installed.
 On Linux, the installer picks:
 
 - `*-unknown-linux-musl` on Alpine
@@ -31,12 +31,6 @@ On Linux, the installer picks:
 The installer adds:
 
 - `jkl`
-- `jkl-sync-fig-autocomplete` (if you answer `y` to the install prompt)
-
-To force this in non-interactive installs, set:
-
-- `JKL_INSTALL_FIG_COMPLETIONS=1` to install
-- `JKL_INSTALL_FIG_COMPLETIONS=0` to skip
 
 ### Release Asset (manual)
 
@@ -69,21 +63,21 @@ If needed, ensure `~/.cargo/bin` is on your `PATH`.
 
 ```
 jkl update
-jkl-sync-fig-autocomplete
+jkl init fig-autocomplete
 ```
 
 To include pre-releases:
 
 ```
 jkl update --pre-release
-jkl-sync-fig-autocomplete
+jkl init fig-autocomplete
 ```
 
 To include dev preview builds from the `dev` branch:
 
 ```
 jkl update --pre-release --dev
-jkl-sync-fig-autocomplete
+jkl init fig-autocomplete
 ```
 
 Master pre-releases are selected from tags that include `-rc.` (for example, `v0.2.0-rc.1`).
@@ -99,7 +93,7 @@ cargo install --git https://github.com/cruzluna/jkl-2 --force
 Then refresh Fig autocomplete:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/scripts/sync-fig-autocomplete.sh | bash
+jkl init fig-autocomplete
 ```
 
 ## Uninstall
@@ -146,6 +140,10 @@ Each archive should contain the `jkl` binary at the top level.
 - Update from stable channel: `jkl update`
 - Update from master pre-release channel: `jkl update --pre-release`
 - Update from dev preview channel: `jkl update --pre-release --dev`
+- Interactive integration setup: `jkl init`
+- Non-interactive hooks setup: `jkl init hooks --tool <claude|kiro> --scope <local|global> --non-interactive [--agent-config-dir <dir>] [--agent-config <path...>]`
+- Non-interactive skills setup: `jkl init skills --tool <codex|claude|kiro> --scope <local|global> --non-interactive`
+- Refresh Fig autocomplete: `jkl init fig-autocomplete`
 - Uninstall binary from current location: `jkl uninstall [--purge-data]`
 - Pane status selector: `jkl tui --pane-state --session-name <session_name...> --pane-id <pane_id>`
 
@@ -199,6 +197,12 @@ set -g @jkl_force_bind_keys 'on'
 
 Claude Code hooks can be configured in `~/.claude/settings.json` (user), `.claude/settings.json` (project), or `.claude/settings.local.json` (local project). The example below marks the current tmux pane as `working` when you submit a prompt, and `waiting` when Claude stops.
 
+Initialize automatically:
+
+```
+jkl init hooks --tool claude --scope global --non-interactive
+```
+
 ```json
 {
   "hooks": {
@@ -235,6 +239,31 @@ Docs:
 
 Kiro CLI hooks are defined in an agent config file (for example `.kiro/agents/jkl.json` in a project, or `~/.kiro/agents/jkl.json` globally). The same pattern can be applied with `userPromptSubmit` and `stop` hooks:
 
+Initialize automatically:
+
+```
+jkl init hooks --tool kiro --scope local --non-interactive
+```
+
+To target specific Kiro agent config files:
+
+```
+jkl init hooks --tool kiro --scope local --non-interactive --agent-config .kiro/agents/dev.json .kiro/agents/reviewer.json
+```
+
+To use a different Kiro agents directory:
+
+```
+jkl init hooks --tool kiro --scope local --non-interactive --agent-config-dir ./custom/kiro/agents
+```
+
+Kiro hooks targeting behavior:
+
+- `--agent-config` updates exactly the listed files (best for automation).
+- `--agent-config-dir` chooses which directory the interactive selector scans.
+- `--agent-config-dir` alone does not update every file automatically.
+- In non-interactive mode, if `--agent-config` is omitted, jkl targets `<agent-config-dir>/jkl.json`.
+
 ```json
 {
   "name": "jkl",
@@ -261,30 +290,29 @@ Docs:
 - https://kiro.dev/docs/cli/hooks/
 - https://kiro.dev/docs/cli/custom-agents/configuration-reference/
 
+### Skills
+
+Initialize skills with `jkl init` interactively, or use non-interactive mode:
+
+```
+jkl init skills --tool codex --scope local --non-interactive
+```
+
+Codex skill paths:
+
+- local: `.agents/skills`
+- global: `~/.agents/skills`
+
 ### Fig autocomplete
 
 A standalone Fig spec for `jkl` lives at:
 
 - `completions/fig/jkl.ts`
 
-User sync script:
-
-- `scripts/sync-fig-autocomplete.sh`
-
-Installed binary helper (from `install.sh`):
-
-- `jkl-sync-fig-autocomplete`
-
-Run either:
+Refresh autocomplete with:
 
 ```
-jkl-sync-fig-autocomplete
-```
-
-or:
-
-```
-curl -fsSL https://raw.githubusercontent.com/cruzluna/jkl-2/master/scripts/sync-fig-autocomplete.sh | bash
+jkl init fig-autocomplete
 ```
 
 ## Session Context

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Each archive should contain the `jkl` binary at the top level.
 - Update from master pre-release channel: `jkl update --pre-release`
 - Update from dev preview channel: `jkl update --pre-release --dev`
 - Interactive integration setup: `jkl init`
-- Non-interactive hooks setup: `jkl init hooks --tool <claude|kiro> --scope <local|global> --non-interactive [--agent-config-dir <dir>] [--agent-config <path...>]`
+- Non-interactive hooks setup: `jkl init hooks --tool <claude|cursor|kiro> --scope <local|global> --non-interactive [--agent-config-dir <dir> (kiro only)] [--agent-config <path...> (kiro/cursor)]`
 - Non-interactive skills setup: `jkl init skills --tool <codex|claude|kiro> --scope <local|global> --non-interactive`
 - Refresh Fig autocomplete: `jkl init fig-autocomplete`
 - Uninstall binary from current location: `jkl uninstall [--purge-data]`
@@ -290,6 +290,52 @@ Docs:
 - https://kiro.dev/docs/cli/hooks/
 - https://kiro.dev/docs/cli/custom-agents/configuration-reference/
 
+### Cursor CLI hooks
+
+Cursor hooks are configured in `hooks.json` at either the user level (`~/.cursor/hooks.json`) or the project level (`<project>/.cursor/hooks.json`).
+
+The example below uses Agent hooks to mirror the Kiro behavior: set the current tmux pane to `working` on `beforeSubmitPrompt`, then back to `waiting` on `stop`.
+
+Initialize automatically:
+
+```
+jkl init hooks --tool cursor --scope local --non-interactive
+```
+
+To target specific Cursor hook config files:
+
+```
+jkl init hooks --tool cursor --scope local --non-interactive --agent-config .cursor/hooks.json ./custom/cursor/hooks.json
+```
+
+Cursor hooks targeting behavior:
+
+- `--agent-config` updates exactly the listed files.
+- In non-interactive mode, if `--agent-config` is omitted, jkl targets the default path from `--scope` (`<project>/.cursor/hooks.json` or `~/.cursor/hooks.json`).
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
+      }
+    ],
+    "stop": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting"
+      }
+    ]
+  }
+}
+```
+
+If you prefer scripts instead of inline commands, note the path difference from Cursor docs: user hooks run from `~/.cursor/` (for example `./hooks/script.sh`), while project hooks run from the project root (for example `.cursor/hooks/script.sh`).
+
+Docs:
+
+- https://cursor.com/docs/agent/hooks
 ### Skills
 
 Initialize skills with `jkl init` interactively, or use non-interactive mode:

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -7,6 +7,7 @@ const statusSuggestions: Fig.Suggestion[] = [
 
 const initToolHooksSuggestions: Fig.Suggestion[] = [
   { name: "claude", description: "Initialize Claude Code hooks" },
+  { name: "cursor", description: "Initialize Cursor hooks" },
   { name: "kiro", description: "Initialize Kiro CLI hooks" },
 ];
 
@@ -230,7 +231,7 @@ const completionSpec: Fig.Spec = {
       subcommands: [
         {
           name: "hooks",
-          description: "Initialize Claude or Kiro hooks",
+          description: "Initialize Claude, Cursor, or Kiro hooks",
           options: [
             {
               name: "--tool",
@@ -259,7 +260,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--agent-config",
               description:
-                "Explicit Kiro agent config file path(s) to update",
+                "Explicit hook config file path(s) to update (Kiro or Cursor)",
               args: {
                 name: "path",
                 isVariadic: true,

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -5,6 +5,22 @@ const statusSuggestions: Fig.Suggestion[] = [
   { name: "none", description: "Clear status / no explicit status" },
 ];
 
+const initToolHooksSuggestions: Fig.Suggestion[] = [
+  { name: "claude", description: "Initialize Claude Code hooks" },
+  { name: "kiro", description: "Initialize Kiro CLI hooks" },
+];
+
+const initToolSkillsSuggestions: Fig.Suggestion[] = [
+  { name: "codex", description: "Initialize Codex skills" },
+  { name: "claude", description: "Initialize Claude skills" },
+  { name: "kiro", description: "Initialize Kiro skills" },
+];
+
+const initScopeSuggestions: Fig.Suggestion[] = [
+  { name: "local", description: "Write config in the current project" },
+  { name: "global", description: "Write config under your HOME directory" },
+];
+
 const sessionNameGenerator: Fig.Generator = {
   script: 'tmux list-sessions -F "#{session_name}" 2>/dev/null',
   postProcess: (output) =>
@@ -207,6 +223,85 @@ const completionSpec: Fig.Spec = {
     {
       name: "sync",
       description: "Sync stored metadata with current tmux sessions and panes",
+    },
+    {
+      name: "init",
+      description: "Initialize hooks, skills, and autocomplete integrations",
+      subcommands: [
+        {
+          name: "hooks",
+          description: "Initialize Claude or Kiro hooks",
+          options: [
+            {
+              name: "--tool",
+              description: "Target integration tool",
+              args: {
+                name: "tool",
+                suggestions: initToolHooksSuggestions,
+              },
+            },
+            {
+              name: "--scope",
+              description: "Where to write hook configuration",
+              args: {
+                name: "scope",
+                suggestions: initScopeSuggestions,
+              },
+            },
+            {
+              name: "--agent-config-dir",
+              description:
+                "Directory to scan for Kiro agent config files during selection (does not update all files automatically)",
+              args: {
+                name: "dir",
+              },
+            },
+            {
+              name: "--agent-config",
+              description:
+                "Explicit Kiro agent config file path(s) to update",
+              args: {
+                name: "path",
+                isVariadic: true,
+              },
+            },
+            {
+              name: "--non-interactive",
+              description: "Fail instead of prompting for missing options",
+            },
+          ],
+        },
+        {
+          name: "skills",
+          description: "Initialize Codex, Claude, or Kiro skills",
+          options: [
+            {
+              name: "--tool",
+              description: "Target integration tool",
+              args: {
+                name: "tool",
+                suggestions: initToolSkillsSuggestions,
+              },
+            },
+            {
+              name: "--scope",
+              description: "Where to write skill configuration",
+              args: {
+                name: "scope",
+                suggestions: initScopeSuggestions,
+              },
+            },
+            {
+              name: "--non-interactive",
+              description: "Fail instead of prompting for missing options",
+            },
+          ],
+        },
+        {
+          name: "fig-autocomplete",
+          description: "Sync jkl spec into Fig and build autocomplete",
+        },
+      ],
     },
     {
       name: "update",

--- a/docs/fig-autocomplete.md
+++ b/docs/fig-autocomplete.md
@@ -4,6 +4,12 @@ This repository includes a Fig completion spec at:
 
 - `completions/fig/jkl.ts`
 
+To sync and build it in your local Fig repository:
+
+```
+jkl init fig-autocomplete
+```
+
 ## Why this approach
 
 `jkl` currently uses `clap` v4, while the documented Rust `clap_complete_fig`

--- a/install.sh
+++ b/install.sh
@@ -3,36 +3,8 @@ set -euo pipefail
 
 BIN_NAME="jkl"
 REPO="cruzluna/jkl-2"
-SYNC_SCRIPT_NAME="jkl-sync-fig-autocomplete"
 INSTALL_DIR="${JKL_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_TAG="${JKL_INSTALL_TAG:-latest}"
-
-should_install_fig_helper() {
-  case "${JKL_INSTALL_FIG_COMPLETIONS:-}" in
-    y|Y|yes|YES|true|TRUE|1) return 0 ;;
-    n|N|no|NO|false|FALSE|0) return 1 ;;
-    "")
-      ;;
-    *)
-      echo "Invalid JKL_INSTALL_FIG_COMPLETIONS value: ${JKL_INSTALL_FIG_COMPLETIONS}" >&2
-      echo "Expected one of: y/n, yes/no, true/false, 1/0" >&2
-      return 1
-      ;;
-  esac
-
-  if [[ -e /dev/tty ]]; then
-    while true; do
-      read -r -p "Install Fig autocomplete helper (${SYNC_SCRIPT_NAME})? [y/n]: " answer </dev/tty
-      case "$answer" in
-        y|Y) return 0 ;;
-        n|N) return 1 ;;
-        *) echo "Please answer y or n." ;;
-      esac
-    done
-  fi
-
-  return 1
-}
 
 is_amazon_linux_2() {
   if [[ -r /etc/os-release ]]; then
@@ -49,7 +21,6 @@ is_amazon_linux_2() {
 
   return 1
 }
-
 uname_s="$(uname -s)"
 uname_m="$(uname -m)"
 
@@ -114,18 +85,6 @@ mv "$tmp_dir/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
 chmod +x "$INSTALL_DIR/$BIN_NAME"
 
 echo "Installed $BIN_NAME to $INSTALL_DIR/$BIN_NAME"
-
-sync_script_url="https://raw.githubusercontent.com/${REPO}/master/scripts/sync-fig-autocomplete.sh"
-if should_install_fig_helper; then
-  if curl -fsSL "$sync_script_url" -o "$INSTALL_DIR/$SYNC_SCRIPT_NAME"; then
-    chmod +x "$INSTALL_DIR/$SYNC_SCRIPT_NAME"
-    echo "Installed $SYNC_SCRIPT_NAME to $INSTALL_DIR/$SYNC_SCRIPT_NAME"
-  else
-    echo "Warning: failed to install $SYNC_SCRIPT_NAME from $sync_script_url" >&2
-  fi
-else
-  echo "Skipped $SYNC_SCRIPT_NAME installation."
-fi
 
 if ! command -v "$BIN_NAME" >/dev/null 2>&1; then
   echo "Make sure $INSTALL_DIR is on your PATH."

--- a/scripts/sync-fig-autocomplete.sh
+++ b/scripts/sync-fig-autocomplete.sh
@@ -42,12 +42,6 @@ ensure_fig_repo_dir() {
     return 0
   fi
 
-  if [[ "$FIG_REPO_DIR" == "$HOME/.fig/autocomplete" && -d "$FALLBACK_FIG_REPO_DIR" ]]; then
-    FIG_REPO_DIR="$FALLBACK_FIG_REPO_DIR"
-    FIG_SPEC_DEST="$FIG_REPO_DIR/src/jkl.ts"
-    return 0
-  fi
-
   if [[ "$AUTO_INIT" != "1" ]]; then
     cat >&2 <<EOF
 Fig autocomplete repo not found at: $FIG_REPO_DIR

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,10 @@
 use anyhow::{Result, bail};
 use clap::{Args, Parser, Subcommand};
 use log::{debug, info};
+use std::path::PathBuf;
 
 use crate::context::{AgentStatus, ContextError};
+use crate::init::{InitScope, InitTool};
 use crate::tui::TuiError;
 
 #[derive(Parser)]
@@ -18,6 +20,7 @@ enum Commands {
     Upsert(UpsertArgs),
     Rename(RenameArgs),
     Sync,
+    Init(InitArgs),
     Update(UpdateArgs),
     Uninstall(UninstallArgs),
 }
@@ -80,6 +83,49 @@ struct UninstallArgs {
     purge_data: bool,
 }
 
+#[derive(Args)]
+struct InitArgs {
+    #[command(subcommand)]
+    command: Option<InitCommands>,
+}
+
+#[derive(Subcommand)]
+enum InitCommands {
+    Hooks(InitHooksArgs),
+    Skills(InitSkillsArgs),
+    FigAutocomplete,
+}
+
+#[derive(Args)]
+struct InitHooksArgs {
+    /// Target integration tool.
+    #[arg(long, value_enum)]
+    tool: Option<InitTool>,
+    /// Where to write configuration (project-local or HOME-global).
+    #[arg(long, value_enum)]
+    scope: Option<InitScope>,
+    /// Directory to scan for Kiro agent config JSON files during selection.
+    /// This does not update all files automatically.
+    #[arg(long = "agent-config-dir", alias = "agents-dir", alias = "agent-dir")]
+    agent_config_dir: Option<PathBuf>,
+    /// Explicit Kiro agent config JSON file path(s) to update.
+    #[arg(long = "agent-config", alias = "config", num_args = 1..)]
+    agent_config: Option<Vec<PathBuf>>,
+    /// Disable prompts; requires explicit options for deterministic automation.
+    #[arg(long)]
+    non_interactive: bool,
+}
+
+#[derive(Args)]
+struct InitSkillsArgs {
+    #[arg(long, value_enum)]
+    tool: Option<InitTool>,
+    #[arg(long, value_enum)]
+    scope: Option<InitScope>,
+    #[arg(long)]
+    non_interactive: bool,
+}
+
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     debug!("cli parsed");
@@ -99,6 +145,10 @@ pub fn run() -> Result<()> {
         Commands::Sync => {
             info!("command=sync");
             handle_sync()?
+        }
+        Commands::Init(args) => {
+            info!("command=init");
+            handle_init(args)?
         }
         Commands::Update(args) => {
             info!("command=update");
@@ -209,6 +259,24 @@ fn resolve_update_channel(args: UpdateArgs) -> Result<crate::update::UpdateChann
     }
 
     Ok(crate::update::UpdateChannel::Stable)
+}
+
+fn handle_init(args: InitArgs) -> Result<()> {
+    eprintln!("Warning: 'jkl init' is experimental and may change without notice.");
+    match args.command {
+        Some(InitCommands::Hooks(cmd)) => crate::init::run_hooks(
+            cmd.tool,
+            cmd.scope,
+            cmd.agent_config_dir,
+            cmd.agent_config,
+            cmd.non_interactive,
+        ),
+        Some(InitCommands::Skills(cmd)) => {
+            crate::init::run_skills(cmd.tool, cmd.scope, cmd.non_interactive)
+        }
+        Some(InitCommands::FigAutocomplete) => crate::init::run_fig_autocomplete(),
+        None => crate::init::run_interactive(),
+    }
 }
 
 fn handle_uninstall(args: UninstallArgs) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,7 +108,7 @@ struct InitHooksArgs {
     /// This does not update all files automatically.
     #[arg(long = "agent-config-dir", alias = "agents-dir", alias = "agent-dir")]
     agent_config_dir: Option<PathBuf>,
-    /// Explicit Kiro agent config JSON file path(s) to update.
+    /// Explicit hook config JSON file path(s) to update (Kiro or Cursor).
     #[arg(long = "agent-config", alias = "config", num_args = 1..)]
     agent_config: Option<Vec<PathBuf>>,
     /// Disable prompts; requires explicit options for deterministic automation.

--- a/src/init.rs
+++ b/src/init.rs
@@ -12,6 +12,8 @@ const CLAUDE_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$
 const CLAUDE_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
 const KIRO_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
 const KIRO_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const CURSOR_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const CURSOR_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
 
 const KIRO_NAME: &str = "jkl";
 const KIRO_DESCRIPTION: &str = "Sync jkl status with Kiro activity";
@@ -23,6 +25,7 @@ const FIG_SPEC: &str = include_str!("../completions/fig/jkl.ts");
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum InitTool {
     Claude,
+    Cursor,
     Kiro,
     Codex,
 }
@@ -32,6 +35,7 @@ impl fmt::Display for InitTool {
         match self {
             Self::Kiro => write!(f, "kiro"),
             Self::Claude => write!(f, "claude"),
+            Self::Cursor => write!(f, "cursor"),
             Self::Codex => write!(f, "codex"),
         }
     }
@@ -100,7 +104,7 @@ pub fn run_hooks(
     let tool = resolve_tool(
         tool,
         non_interactive,
-        &[InitTool::Claude, InitTool::Kiro],
+        &[InitTool::Claude, InitTool::Cursor, InitTool::Kiro],
         "Select the tool to initialize hooks for:",
         "--tool is required when using --non-interactive",
     )?;
@@ -109,10 +113,10 @@ pub fn run_hooks(
     match tool {
         InitTool::Claude => {
             if config_paths.is_some() {
-                bail!("--config is only supported for --tool kiro");
+                bail!("--agent-config is only supported for --tool kiro or cursor");
             }
             if agents_dir.is_some() {
-                bail!("--agents-dir is only supported for --tool kiro");
+                bail!("--agent-config-dir is only supported for --tool kiro");
             }
             let path = hooks_config_path(tool, scope)?;
             apply_hooks_to_file(&path, tool)?;
@@ -123,6 +127,15 @@ pub fn run_hooks(
                 println!("No Kiro agent configs selected. No files updated.");
                 return Ok(());
             }
+            for path in paths {
+                apply_hooks_to_file(&path, tool)?;
+            }
+        }
+        InitTool::Cursor => {
+            if agents_dir.is_some() {
+                bail!("--agent-config-dir is only supported for --tool kiro");
+            }
+            let paths = resolve_cursor_hook_paths(scope, config_paths)?;
             for path in paths {
                 apply_hooks_to_file(&path, tool)?;
             }
@@ -242,6 +255,7 @@ fn apply_hooks_to_file(path: &Path, tool: InitTool) -> Result<()> {
     let mut root = load_json_object_or_empty(path)?;
     let changed = match tool {
         InitTool::Claude => ensure_claude_hooks(&mut root)?,
+        InitTool::Cursor => ensure_cursor_hooks(&mut root)?,
         InitTool::Kiro => ensure_kiro_hooks(&mut root)?,
         InitTool::Codex => bail!("codex does not support hooks"),
     };
@@ -264,6 +278,10 @@ fn hooks_config_path(tool: InitTool, scope: InitScope) -> Result<PathBuf> {
         (InitTool::Claude, InitScope::Local) => std::env::current_dir()?
             .join(".claude")
             .join("settings.local.json"),
+        (InitTool::Cursor, InitScope::Global) => home.join(".cursor").join("hooks.json"),
+        (InitTool::Cursor, InitScope::Local) => {
+            std::env::current_dir()?.join(".cursor").join("hooks.json")
+        }
         (InitTool::Kiro, InitScope::Global) => home.join(".kiro").join("agents").join("jkl.json"),
         (InitTool::Kiro, InitScope::Local) => std::env::current_dir()?
             .join(".kiro")
@@ -309,6 +327,17 @@ fn resolve_kiro_hook_paths(
     }
 
     select_kiro_configs_with_enter(detected)
+}
+
+fn resolve_cursor_hook_paths(
+    scope: InitScope,
+    config_paths: Option<Vec<PathBuf>>,
+) -> Result<Vec<PathBuf>> {
+    if let Some(paths) = config_paths {
+        return normalize_user_paths(paths);
+    }
+
+    Ok(vec![hooks_config_path(InitTool::Cursor, scope)?])
 }
 
 fn discover_kiro_agent_configs(agents_dir: &Path) -> Result<Vec<PathChoice>> {
@@ -451,6 +480,7 @@ fn skills_root_path(tool: InitTool, scope: InitScope) -> Result<PathBuf> {
         (InitTool::Codex, InitScope::Global) => home.join(".agents").join("skills"),
         (InitTool::Claude, InitScope::Local) => cwd.join(".claude").join("skills"),
         (InitTool::Claude, InitScope::Global) => home.join(".claude").join("skills"),
+        (InitTool::Cursor, _) => bail!("cursor does not support skills"),
         (InitTool::Kiro, InitScope::Local) => cwd.join(".kiro").join("skills"),
         (InitTool::Kiro, InitScope::Global) => home.join(".kiro").join("skills"),
     })
@@ -558,6 +588,41 @@ fn ensure_kiro_hooks(root: &mut Value) -> Result<bool> {
 }
 
 fn ensure_kiro_hook_event(
+    hooks: &mut Map<String, Value>,
+    event: &str,
+    command: &str,
+) -> Result<bool> {
+    let event_entries = array_field(hooks, event)?;
+
+    if event_entries
+        .iter()
+        .any(|entry| entry.get("command").and_then(Value::as_str) == Some(command))
+    {
+        return Ok(false);
+    }
+
+    event_entries.push(json!({ "command": command }));
+    Ok(true)
+}
+
+fn ensure_cursor_hooks(root: &mut Value) -> Result<bool> {
+    let root_obj = root
+        .as_object_mut()
+        .context("cursor config root must be a JSON object")?;
+
+    let mut changed = false;
+    if !root_obj.contains_key("version") {
+        root_obj.insert("version".to_string(), json!(1));
+        changed = true;
+    }
+
+    let hooks = object_field(root_obj, "hooks")?;
+    changed |= ensure_cursor_hook_event(hooks, "beforeSubmitPrompt", CURSOR_WORKING_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "stop", CURSOR_WAITING_COMMAND)?;
+    Ok(changed)
+}
+
+fn ensure_cursor_hook_event(
     hooks: &mut Map<String, Value>,
     event: &str,
     command: &str,
@@ -733,6 +798,30 @@ mod tests {
     }
 
     #[test]
+    fn hooks_path_for_cursor_resolves_global_and_local() {
+        let mut env = EnvGuard::new("init-hooks-cursor-paths");
+        let home = env.set_temp_home();
+        let cwd = env.temp_dir().join("project");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let previous_cwd = std::env::current_dir().expect("current cwd");
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+        let _cwd_guard = CwdGuard(previous_cwd);
+        std::env::set_current_dir(&cwd).expect("set cwd");
+
+        let global = hooks_config_path(InitTool::Cursor, InitScope::Global).expect("global path");
+        let local = hooks_config_path(InitTool::Cursor, InitScope::Local).expect("local path");
+
+        assert_eq!(global, home.join(".cursor").join("hooks.json"));
+        let cwd_resolved = std::env::current_dir().expect("resolved cwd");
+        assert_eq!(local, cwd_resolved.join(".cursor").join("hooks.json"));
+    }
+
+    #[test]
     fn ensure_claude_hooks_is_idempotent() {
         let mut root = json!({});
 
@@ -772,6 +861,33 @@ mod tests {
             .and_then(Value::as_array)
             .expect("stop array");
         assert_eq!(stop.len(), 1);
+    }
+
+    #[test]
+    fn ensure_cursor_hooks_is_idempotent() {
+        let mut root = json!({});
+
+        let first = ensure_cursor_hooks(&mut root).expect("first ensure");
+        let second = ensure_cursor_hooks(&mut root).expect("second ensure");
+
+        assert!(first);
+        assert!(!second);
+
+        let version = root
+            .get("version")
+            .and_then(Value::as_i64)
+            .expect("version");
+        assert_eq!(version, 1);
+
+        let hooks = root
+            .get("hooks")
+            .and_then(Value::as_object)
+            .expect("hooks object");
+        let submit = hooks
+            .get("beforeSubmitPrompt")
+            .and_then(Value::as_array)
+            .expect("beforeSubmitPrompt array");
+        assert_eq!(submit.len(), 1);
     }
 
     #[test]
@@ -825,5 +941,17 @@ mod tests {
             resolve_kiro_hook_paths(InitScope::Local, Some(override_dir.clone()), None, true)
                 .expect("resolve paths");
         assert_eq!(paths, vec![override_dir.join("jkl.json")]);
+    }
+
+    #[test]
+    fn resolve_cursor_hook_paths_uses_explicit_paths() {
+        let env = EnvGuard::new("init-cursor-path-override");
+        let cwd = env.temp_dir().join("project");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let explicit = cwd.join(".cursor").join("dev-hooks.json");
+
+        let resolved = resolve_cursor_hook_paths(InitScope::Local, Some(vec![explicit.clone()]))
+            .expect("resolve cursor paths");
+        assert_eq!(resolved, vec![explicit]);
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,829 @@
+use anyhow::{Context, Result, bail};
+use clap::ValueEnum;
+use inquire::{Select, Text};
+use serde_json::{Map, Value, json};
+use std::fmt;
+use std::fs;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const CLAUDE_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const CLAUDE_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const KIRO_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const KIRO_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+
+const KIRO_NAME: &str = "jkl";
+const KIRO_DESCRIPTION: &str = "Sync jkl status with Kiro activity";
+
+const JKL_SKILL_MD: &str = include_str!("../skills/jkl-cli/SKILL.md");
+const JKL_SKILL_OPENAI_YAML: &str = include_str!("../skills/jkl-cli/agents/openai.yaml");
+const FIG_SPEC: &str = include_str!("../completions/fig/jkl.ts");
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum InitTool {
+    Claude,
+    Kiro,
+    Codex,
+}
+
+impl fmt::Display for InitTool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Kiro => write!(f, "kiro"),
+            Self::Claude => write!(f, "claude"),
+            Self::Codex => write!(f, "codex"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum InitScope {
+    Local,
+    Global,
+}
+
+impl fmt::Display for InitScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local => write!(f, "local"),
+            Self::Global => write!(f, "global"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InitTarget {
+    Hooks,
+    Skills,
+    FigAutocomplete,
+}
+
+impl fmt::Display for InitTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hooks => write!(f, "hooks"),
+            Self::Skills => write!(f, "skills"),
+            Self::FigAutocomplete => write!(f, "fig-autocomplete"),
+        }
+    }
+}
+
+pub fn run_interactive() -> Result<()> {
+    ensure_interactive_terminal()?;
+
+    let target = Select::new(
+        "What do you want to initialize?",
+        vec![
+            InitTarget::Hooks,
+            InitTarget::Skills,
+            InitTarget::FigAutocomplete,
+        ],
+    )
+    .prompt()
+    .context("prompt for init target")?;
+
+    match target {
+        InitTarget::Hooks => run_hooks(None, None, None, None, false),
+        InitTarget::Skills => run_skills(None, None, false),
+        InitTarget::FigAutocomplete => run_fig_autocomplete(),
+    }
+}
+
+pub fn run_hooks(
+    tool: Option<InitTool>,
+    scope: Option<InitScope>,
+    agents_dir: Option<PathBuf>,
+    config_paths: Option<Vec<PathBuf>>,
+    non_interactive: bool,
+) -> Result<()> {
+    let tool = resolve_tool(
+        tool,
+        non_interactive,
+        &[InitTool::Claude, InitTool::Kiro],
+        "Select the tool to initialize hooks for:",
+        "--tool is required when using --non-interactive",
+    )?;
+    let scope = resolve_scope(scope, non_interactive)?;
+
+    match tool {
+        InitTool::Claude => {
+            if config_paths.is_some() {
+                bail!("--config is only supported for --tool kiro");
+            }
+            if agents_dir.is_some() {
+                bail!("--agents-dir is only supported for --tool kiro");
+            }
+            let path = hooks_config_path(tool, scope)?;
+            apply_hooks_to_file(&path, tool)?;
+        }
+        InitTool::Kiro => {
+            let paths = resolve_kiro_hook_paths(scope, agents_dir, config_paths, non_interactive)?;
+            if paths.is_empty() {
+                println!("No Kiro agent configs selected. No files updated.");
+                return Ok(());
+            }
+            for path in paths {
+                apply_hooks_to_file(&path, tool)?;
+            }
+        }
+        InitTool::Codex => bail!("codex does not support hooks"),
+    }
+
+    Ok(())
+}
+
+pub fn run_skills(
+    tool: Option<InitTool>,
+    scope: Option<InitScope>,
+    non_interactive: bool,
+) -> Result<()> {
+    let tool = resolve_tool(
+        tool,
+        non_interactive,
+        &[InitTool::Codex, InitTool::Claude, InitTool::Kiro],
+        "Select the tool to initialize skills for:",
+        "--tool is required when using --non-interactive",
+    )?;
+    let scope = resolve_scope(scope, non_interactive)?;
+
+    let root = skills_root_path(tool, scope)?;
+    let skill_dir = root.join("jkl-cli");
+    let skill_md = skill_dir.join("SKILL.md");
+    let agent_yaml = skill_dir.join("agents").join("openai.yaml");
+
+    let mut changed_files = 0;
+    changed_files += usize::from(write_file_if_changed(&skill_md, JKL_SKILL_MD.as_bytes())?);
+    changed_files += usize::from(write_file_if_changed(
+        &agent_yaml,
+        JKL_SKILL_OPENAI_YAML.as_bytes(),
+    )?);
+
+    if changed_files > 0 {
+        println!(
+            "Initialized jkl skill for {} at {}",
+            tool,
+            skill_dir.display()
+        );
+    } else {
+        println!("Skill already up to date at {}", skill_dir.display());
+    }
+
+    Ok(())
+}
+
+pub fn run_fig_autocomplete() -> Result<()> {
+    let fig_repo_dir = ensure_fig_repo_dir()?;
+
+    if !command_in_path("npm") {
+        bail!("npm is required but was not found in PATH");
+    }
+
+    let spec_dest = fig_repo_dir.join("src").join("jkl.ts");
+    write_file_if_changed(&spec_dest, FIG_SPEC.as_bytes())?;
+    println!("Synced spec to: {}", spec_dest.display());
+
+    run_command(
+        Command::new("npm")
+            .arg("run")
+            .arg("build")
+            .current_dir(&fig_repo_dir),
+        "build Fig autocomplete",
+    )?;
+
+    println!("Fig autocomplete build complete.");
+    Ok(())
+}
+
+fn resolve_tool(
+    tool: Option<InitTool>,
+    non_interactive: bool,
+    allowed_tools: &[InitTool],
+    prompt: &str,
+    missing_tool_message: &str,
+) -> Result<InitTool> {
+    if let Some(tool) = tool {
+        if allowed_tools.contains(&tool) {
+            return Ok(tool);
+        }
+        bail!("unsupported tool '{}' for this init command", tool);
+    }
+
+    if non_interactive {
+        bail!("{missing_tool_message}");
+    }
+
+    ensure_interactive_terminal()?;
+    Select::new(prompt, allowed_tools.to_vec())
+        .prompt()
+        .context("prompt for tool selection")
+}
+
+fn resolve_scope(scope: Option<InitScope>, non_interactive: bool) -> Result<InitScope> {
+    if let Some(scope) = scope {
+        return Ok(scope);
+    }
+
+    if non_interactive {
+        bail!("--scope is required when using --non-interactive");
+    }
+
+    ensure_interactive_terminal()?;
+    Select::new(
+        "Select where to initialize:",
+        vec![InitScope::Local, InitScope::Global],
+    )
+    .prompt()
+    .context("prompt for scope selection")
+}
+
+fn apply_hooks_to_file(path: &Path, tool: InitTool) -> Result<()> {
+    let existed_before = path.exists();
+    let mut root = load_json_object_or_empty(path)?;
+    let changed = match tool {
+        InitTool::Claude => ensure_claude_hooks(&mut root)?,
+        InitTool::Kiro => ensure_kiro_hooks(&mut root)?,
+        InitTool::Codex => bail!("codex does not support hooks"),
+    };
+
+    if changed || !existed_before {
+        write_json_pretty(path, &root)?;
+        println!("Initialized hooks at {}", path.display());
+    } else {
+        println!("Hooks already configured at {}", path.display());
+    }
+
+    Ok(())
+}
+
+fn hooks_config_path(tool: InitTool, scope: InitScope) -> Result<PathBuf> {
+    let home = home_dir()?;
+
+    Ok(match (tool, scope) {
+        (InitTool::Claude, InitScope::Global) => home.join(".claude").join("settings.json"),
+        (InitTool::Claude, InitScope::Local) => std::env::current_dir()?
+            .join(".claude")
+            .join("settings.local.json"),
+        (InitTool::Kiro, InitScope::Global) => home.join(".kiro").join("agents").join("jkl.json"),
+        (InitTool::Kiro, InitScope::Local) => std::env::current_dir()?
+            .join(".kiro")
+            .join("agents")
+            .join("jkl.json"),
+        (InitTool::Codex, _) => bail!("codex does not support hooks"),
+    })
+}
+
+fn kiro_agents_dir(scope: InitScope) -> Result<PathBuf> {
+    let home = home_dir()?;
+    let cwd = std::env::current_dir()?;
+    Ok(match scope {
+        InitScope::Local => cwd.join(".kiro").join("agents"),
+        InitScope::Global => home.join(".kiro").join("agents"),
+    })
+}
+
+fn resolve_kiro_hook_paths(
+    scope: InitScope,
+    agents_dir_override: Option<PathBuf>,
+    config_paths: Option<Vec<PathBuf>>,
+    non_interactive: bool,
+) -> Result<Vec<PathBuf>> {
+    if let Some(paths) = config_paths {
+        let normalized = normalize_user_paths(paths)?;
+        if normalized.is_empty() {
+            bail!("at least one --config path is required");
+        }
+        return Ok(normalized);
+    }
+
+    let agents_dir = resolve_kiro_agents_dir(scope, agents_dir_override, non_interactive)?;
+
+    if non_interactive {
+        return Ok(vec![agents_dir.join("jkl.json")]);
+    }
+
+    ensure_interactive_terminal()?;
+    let detected = discover_kiro_agent_configs(&agents_dir)?;
+    if detected.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    select_kiro_configs_with_enter(detected)
+}
+
+fn discover_kiro_agent_configs(agents_dir: &Path) -> Result<Vec<PathChoice>> {
+    if !agents_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut choices = Vec::new();
+    for entry in fs::read_dir(agents_dir)
+        .with_context(|| format!("read Kiro agents directory {}", agents_dir.display()))?
+    {
+        let entry = entry.context("read directory entry")?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown.json");
+        choices.push(PathChoice {
+            label: format!("{} ({})", file_name, path.display()),
+            path,
+        });
+    }
+    choices.sort_by(|a, b| a.label.cmp(&b.label));
+    Ok(choices)
+}
+
+fn select_kiro_configs_with_enter(detected: Vec<PathChoice>) -> Result<Vec<PathBuf>> {
+    let mut remaining = detected;
+    let mut selected = Vec::new();
+
+    loop {
+        let mut options: Vec<String> = remaining
+            .iter()
+            .map(|choice| choice.label.clone())
+            .collect();
+        options.push("Finish selection".to_string());
+
+        let prompt = format!(
+            "Select Kiro agent config file (selected: {}, Enter to choose):",
+            selected.len()
+        );
+        let picked = Select::new(prompt.as_str(), options)
+            .prompt()
+            .context("prompt for Kiro config file selection")?;
+
+        if picked == "Finish selection" {
+            break;
+        }
+
+        if let Some(index) = remaining.iter().position(|choice| choice.label == picked) {
+            let choice = remaining.remove(index);
+            selected.push(choice.path);
+        }
+
+        if remaining.is_empty() {
+            break;
+        }
+    }
+
+    Ok(selected)
+}
+
+fn resolve_kiro_agents_dir(
+    scope: InitScope,
+    override_dir: Option<PathBuf>,
+    non_interactive: bool,
+) -> Result<PathBuf> {
+    let default_dir = kiro_agents_dir(scope)?;
+    if let Some(dir) = override_dir {
+        return absolutize_path(dir);
+    }
+
+    if non_interactive {
+        return Ok(default_dir);
+    }
+
+    ensure_interactive_terminal()?;
+    let raw = Text::new(&format!(
+        "Agent config directory [{}]:",
+        default_dir.display()
+    ))
+    .with_help_message("specify override")
+    .prompt()
+    .context("prompt for Kiro agents directory")?;
+
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(default_dir);
+    }
+    absolutize_path(PathBuf::from(trimmed))
+}
+
+fn absolutize_path(path: PathBuf) -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("resolve current working directory")?;
+    Ok(absolutize_from(path, &cwd))
+}
+
+fn absolutize_from(path: PathBuf, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn normalize_user_paths(paths: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    let cwd = std::env::current_dir().context("resolve current working directory")?;
+    normalize_user_paths_from(paths, &cwd)
+}
+
+fn normalize_user_paths_from(paths: Vec<PathBuf>, cwd: &Path) -> Result<Vec<PathBuf>> {
+    let mut normalized = Vec::new();
+    for path in paths {
+        if path.as_os_str().is_empty() {
+            continue;
+        }
+        let resolved = absolutize_from(path, cwd);
+        if !normalized.iter().any(|existing| existing == &resolved) {
+            normalized.push(resolved);
+        }
+    }
+    if normalized.is_empty() {
+        bail!("at least one config path is required");
+    }
+    Ok(normalized)
+}
+
+fn skills_root_path(tool: InitTool, scope: InitScope) -> Result<PathBuf> {
+    let home = home_dir()?;
+    let cwd = std::env::current_dir()?;
+
+    Ok(match (tool, scope) {
+        (InitTool::Codex, InitScope::Local) => cwd.join(".agents").join("skills"),
+        (InitTool::Codex, InitScope::Global) => home.join(".agents").join("skills"),
+        (InitTool::Claude, InitScope::Local) => cwd.join(".claude").join("skills"),
+        (InitTool::Claude, InitScope::Global) => home.join(".claude").join("skills"),
+        (InitTool::Kiro, InitScope::Local) => cwd.join(".kiro").join("skills"),
+        (InitTool::Kiro, InitScope::Global) => home.join(".kiro").join("skills"),
+    })
+}
+
+fn load_json_object_or_empty(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Ok(Value::Object(Map::new()));
+    }
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("read JSON config at {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(Value::Object(Map::new()));
+    }
+
+    let parsed: Value = serde_json::from_str(&content)
+        .with_context(|| format!("parse JSON config at {}", path.display()))?;
+    if !parsed.is_object() {
+        bail!("expected JSON object at {}", path.display());
+    }
+
+    Ok(parsed)
+}
+
+fn write_json_pretty(path: &Path, value: &Value) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("resolve config file parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create config directory {}", parent.display()))?;
+
+    let serialized = serde_json::to_string_pretty(value).context("serialize JSON config")?;
+    fs::write(path, format!("{serialized}\n"))
+        .with_context(|| format!("write JSON config at {}", path.display()))
+}
+
+fn ensure_claude_hooks(root: &mut Value) -> Result<bool> {
+    let mut changed = false;
+    changed |= ensure_claude_hook(root, "UserPromptSubmit", CLAUDE_WORKING_COMMAND)?;
+    changed |= ensure_claude_hook(root, "Stop", CLAUDE_WAITING_COMMAND)?;
+    Ok(changed)
+}
+
+fn ensure_claude_hook(root: &mut Value, event: &str, command: &str) -> Result<bool> {
+    let root_obj = root
+        .as_object_mut()
+        .context("claude config root must be a JSON object")?;
+    let hooks = object_field(root_obj, "hooks")?;
+    let event_entries = array_field(hooks, event)?;
+
+    if claude_event_contains_command(event_entries, command) {
+        return Ok(false);
+    }
+
+    event_entries.push(json!({
+        "hooks": [
+            {
+                "type": "command",
+                "command": command
+            }
+        ]
+    }));
+
+    Ok(true)
+}
+
+fn claude_event_contains_command(entries: &[Value], command: &str) -> bool {
+    entries.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(Value::as_array)
+            .is_some_and(|hooks| {
+                hooks.iter().any(|hook| {
+                    hook.get("type").and_then(Value::as_str) == Some("command")
+                        && hook.get("command").and_then(Value::as_str) == Some(command)
+                })
+            })
+    })
+}
+
+fn ensure_kiro_hooks(root: &mut Value) -> Result<bool> {
+    let root_obj = root
+        .as_object_mut()
+        .context("kiro config root must be a JSON object")?;
+
+    let mut changed = false;
+    if !root_obj.contains_key("name") {
+        root_obj.insert("name".to_string(), Value::String(KIRO_NAME.to_string()));
+        changed = true;
+    }
+    if !root_obj.contains_key("description") {
+        root_obj.insert(
+            "description".to_string(),
+            Value::String(KIRO_DESCRIPTION.to_string()),
+        );
+        changed = true;
+    }
+
+    let hooks = object_field(root_obj, "hooks")?;
+    changed |= ensure_kiro_hook_event(hooks, "userPromptSubmit", KIRO_WORKING_COMMAND)?;
+    changed |= ensure_kiro_hook_event(hooks, "stop", KIRO_WAITING_COMMAND)?;
+
+    Ok(changed)
+}
+
+fn ensure_kiro_hook_event(
+    hooks: &mut Map<String, Value>,
+    event: &str,
+    command: &str,
+) -> Result<bool> {
+    let event_entries = array_field(hooks, event)?;
+
+    if event_entries
+        .iter()
+        .any(|entry| entry.get("command").and_then(Value::as_str) == Some(command))
+    {
+        return Ok(false);
+    }
+
+    event_entries.push(json!({ "command": command }));
+    Ok(true)
+}
+
+fn object_field<'a>(
+    object: &'a mut Map<String, Value>,
+    key: &str,
+) -> Result<&'a mut Map<String, Value>> {
+    let value = object
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    value
+        .as_object_mut()
+        .with_context(|| format!("'{}' must be a JSON object", key))
+}
+
+fn array_field<'a>(object: &'a mut Map<String, Value>, key: &str) -> Result<&'a mut Vec<Value>> {
+    let value = object
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    value
+        .as_array_mut()
+        .with_context(|| format!("'{}' must be a JSON array", key))
+}
+
+fn write_file_if_changed(path: &Path, content: &[u8]) -> Result<bool> {
+    if let Ok(existing) = fs::read(path) {
+        if existing == content {
+            return Ok(false);
+        }
+    }
+
+    let parent = path
+        .parent()
+        .context("resolve destination file parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create destination directory {}", parent.display()))?;
+    fs::write(path, content).with_context(|| format!("write file {}", path.display()))?;
+    Ok(true)
+}
+
+fn ensure_fig_repo_dir() -> Result<PathBuf> {
+    let home = home_dir()?;
+    let default_dir = home.join(".fig").join("autocomplete");
+    let fallback_dir = home.join(".fig").join(".fig").join("autocomplete");
+
+    let env_override = std::env::var_os("FIG_AUTOCOMPLETE_DIR");
+    let mut repo_dir = env_override
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_dir.clone());
+
+    if repo_dir.is_dir() {
+        return Ok(repo_dir);
+    }
+
+    if !command_in_path("npx") {
+        bail!(
+            "Fig autocomplete repo not found at {} and npx is required to initialize it",
+            repo_dir.display()
+        );
+    }
+
+    let mut init_dir = repo_dir
+        .parent()
+        .context("resolve Fig autocomplete repository parent directory")?;
+    if env_override.is_none() && repo_dir == default_dir {
+        init_dir = &home;
+    }
+    fs::create_dir_all(init_dir)
+        .with_context(|| format!("create Fig parent directory {}", init_dir.display()))?;
+
+    run_command(
+        Command::new("npx")
+            .arg("@withfig/autocomplete-tools@latest")
+            .arg("init")
+            .current_dir(init_dir),
+        "initialize Fig autocomplete repository",
+    )?;
+
+    if repo_dir.is_dir() {
+        return Ok(repo_dir);
+    }
+
+    if env_override.is_none() && fallback_dir.is_dir() {
+        repo_dir = fallback_dir;
+        return Ok(repo_dir);
+    }
+
+    bail!(
+        "failed to initialize Fig autocomplete repository at {}",
+        repo_dir.display()
+    )
+}
+
+fn command_in_path(command: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(command).is_file())
+}
+
+fn run_command(command: &mut Command, action: &str) -> Result<()> {
+    let status = command
+        .status()
+        .with_context(|| format!("{}: start command", action))?;
+    if status.success() {
+        return Ok(());
+    }
+
+    bail!("{}: command exited with {}", action, status)
+}
+
+fn ensure_interactive_terminal() -> Result<()> {
+    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        return Ok(());
+    }
+
+    bail!("interactive init requires a terminal; use --non-interactive with explicit flags")
+}
+
+fn home_dir() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home))
+}
+
+#[derive(Clone, Debug)]
+struct PathChoice {
+    label: String,
+    path: PathBuf,
+}
+
+impl fmt::Display for PathChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::EnvGuard;
+
+    #[test]
+    fn skills_root_for_codex_global_uses_home_agents_skills() {
+        let mut env = EnvGuard::new("init-skills-root-codex-global");
+        let home = env.set_temp_home();
+
+        let root = skills_root_path(InitTool::Codex, InitScope::Global).expect("skills root");
+        assert_eq!(root, home.join(".agents").join("skills"));
+    }
+
+    #[test]
+    fn hooks_path_rejects_codex() {
+        let mut env = EnvGuard::new("init-hooks-codex-reject");
+        env.set_temp_home();
+
+        let err = hooks_config_path(InitTool::Codex, InitScope::Local).expect_err("expected error");
+        assert!(err.to_string().contains("does not support hooks"));
+    }
+
+    #[test]
+    fn ensure_claude_hooks_is_idempotent() {
+        let mut root = json!({});
+
+        let first = ensure_claude_hooks(&mut root).expect("first ensure");
+        let second = ensure_claude_hooks(&mut root).expect("second ensure");
+
+        assert!(first);
+        assert!(!second);
+
+        let hooks = root
+            .get("hooks")
+            .and_then(Value::as_object)
+            .expect("hooks object");
+        let submit = hooks
+            .get("UserPromptSubmit")
+            .and_then(Value::as_array)
+            .expect("submit array");
+        assert_eq!(submit.len(), 1);
+    }
+
+    #[test]
+    fn ensure_kiro_hooks_is_idempotent() {
+        let mut root = json!({});
+
+        let first = ensure_kiro_hooks(&mut root).expect("first ensure");
+        let second = ensure_kiro_hooks(&mut root).expect("second ensure");
+
+        assert!(first);
+        assert!(!second);
+
+        let hooks = root
+            .get("hooks")
+            .and_then(Value::as_object)
+            .expect("hooks object");
+        let stop = hooks
+            .get("stop")
+            .and_then(Value::as_array)
+            .expect("stop array");
+        assert_eq!(stop.len(), 1);
+    }
+
+    #[test]
+    fn write_file_if_changed_skips_unchanged() {
+        let env = EnvGuard::new("init-write-file-if-changed");
+        let path = env.temp_dir().join("file.txt");
+
+        let first = write_file_if_changed(&path, b"hello").expect("first write");
+        let second = write_file_if_changed(&path, b"hello").expect("second write");
+
+        assert!(first);
+        assert!(!second);
+    }
+
+    #[test]
+    fn normalize_user_paths_deduplicates_and_resolves_relative_paths() {
+        let env = EnvGuard::new("init-normalize-paths");
+        let cwd = env.temp_dir().join("project");
+        fs::create_dir_all(&cwd).expect("create cwd");
+
+        let paths = vec![
+            PathBuf::from(".kiro/agents/a.json"),
+            PathBuf::from(".kiro/agents/a.json"),
+            PathBuf::from("/tmp/absolute.json"),
+        ];
+
+        let normalized = normalize_user_paths_from(paths, &cwd).expect("normalize");
+        assert_eq!(normalized.len(), 2);
+        assert_eq!(normalized[0], cwd.join(".kiro/agents/a.json"));
+        assert_eq!(normalized[1], PathBuf::from("/tmp/absolute.json"));
+    }
+
+    #[test]
+    fn absolutize_from_keeps_absolute_and_resolves_relative() {
+        let cwd = PathBuf::from("/tmp/root");
+        assert_eq!(
+            absolutize_from(PathBuf::from("a/b.json"), &cwd),
+            PathBuf::from("/tmp/root/a/b.json")
+        );
+        assert_eq!(
+            absolutize_from(PathBuf::from("/etc/test.json"), &cwd),
+            PathBuf::from("/etc/test.json")
+        );
+    }
+
+    #[test]
+    fn resolve_kiro_hook_paths_non_interactive_uses_override_directory() {
+        let env = EnvGuard::new("init-kiro-dir-override");
+        let override_dir = env.temp_dir().join("custom").join("agents");
+        let paths =
+            resolve_kiro_hook_paths(InitScope::Local, Some(override_dir.clone()), None, true)
+                .expect("resolve paths");
+        assert_eq!(paths, vec![override_dir.join("jkl.json")]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod context;
+mod init;
 #[cfg(test)]
 mod test_utils;
 mod tmux;

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -2,14 +2,10 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const FIG_HELPER_NAME: &str = "jkl-sync-fig-autocomplete";
-
 #[derive(Debug)]
 struct UninstallSummary {
     binary_path: PathBuf,
-    helper_path: PathBuf,
     removed_binary: bool,
-    removed_helper: bool,
     removed_config: Option<bool>,
     config_path: Option<PathBuf>,
 }
@@ -30,12 +26,6 @@ pub fn run(purge_data: bool) -> Result<()> {
         println!("Removed {}", summary.binary_path.display());
     } else {
         println!("Binary already missing: {}", summary.binary_path.display());
-    }
-
-    if summary.removed_helper {
-        println!("Removed {}", summary.helper_path.display());
-    } else {
-        println!("Helper not found: {}", summary.helper_path.display());
     }
 
     if let Some(removed) = summary.removed_config {
@@ -59,15 +49,9 @@ fn uninstall_paths(
     purge_data: bool,
 ) -> Result<UninstallSummary> {
     let binary_path = exe_path.to_path_buf();
-    let parent = exe_path
-        .parent()
-        .context("resolve executable parent directory")?;
-    let helper_path = parent.join(FIG_HELPER_NAME);
 
     let removed_binary = remove_file_if_exists(&binary_path)
         .with_context(|| format!("remove binary at {}", binary_path.display()))?;
-    let removed_helper = remove_file_if_exists(&helper_path)
-        .with_context(|| format!("remove helper at {}", helper_path.display()))?;
 
     let (removed_config, config_path) = if purge_data {
         let home = home_dir.context("missing home directory for config cleanup")?;
@@ -81,9 +65,7 @@ fn uninstall_paths(
 
     Ok(UninstallSummary {
         binary_path,
-        helper_path,
         removed_binary,
-        removed_helper,
         removed_config,
         config_path,
     })
@@ -111,29 +93,24 @@ mod tests {
     use crate::test_utils::EnvGuard;
 
     #[test]
-    fn uninstall_paths_removes_binary_and_helper() {
+    fn uninstall_paths_removes_binary() {
         let env = EnvGuard::new("uninstall-remove-files");
         let exe = env.temp_dir().join("jkl");
-        let helper = env.temp_dir().join(FIG_HELPER_NAME);
 
         fs::write(&exe, "bin").expect("write exe");
-        fs::write(&helper, "helper").expect("write helper");
 
         let summary = uninstall_paths(&exe, None, false).expect("uninstall");
         assert!(summary.removed_binary);
-        assert!(summary.removed_helper);
         assert!(!exe.exists());
-        assert!(!helper.exists());
     }
 
     #[test]
-    fn uninstall_paths_handles_missing_files() {
+    fn uninstall_paths_handles_missing_binary() {
         let env = EnvGuard::new("uninstall-missing-files");
         let exe = env.temp_dir().join("jkl");
 
         let summary = uninstall_paths(&exe, None, false).expect("uninstall");
         assert!(!summary.removed_binary);
-        assert!(!summary.removed_helper);
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, bail};
 use self_update::backends::github::ReleaseList;
 use self_update::update::{Release, ReleaseAsset};
 use std::fs;
-use std::path::PathBuf;
 
 const REPO_OWNER: &str = "cruzluna";
 const REPO_NAME: &str = "jkl-2";
@@ -162,16 +161,6 @@ fn find_channel_tag(
     select_channel_tag(&releases, channel).ok_or_else(|| anyhow::anyhow!(channel.not_found_error()))
 }
 
-fn command_in_path(command: &str) -> bool {
-    let Some(path) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| {
-        let candidate: PathBuf = dir.join(command);
-        candidate.is_file()
-    })
-}
-
 pub fn run(channel: UpdateChannel) -> Result<()> {
     let config = update_config();
     let current_version = self_update::cargo_crate_version!();
@@ -222,13 +211,7 @@ pub fn run(channel: UpdateChannel) -> Result<()> {
         log::info!("already up-to-date");
     }
 
-    if command_in_path("jkl-sync-fig-autocomplete") {
-        println!("To refresh Fig autocomplete, run: jkl-sync-fig-autocomplete");
-    } else {
-        println!(
-            "To refresh Fig autocomplete, run:\n  curl -fsSL https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/master/scripts/sync-fig-autocomplete.sh | bash"
-        );
-    }
+    println!("To refresh Fig autocomplete, run: jkl init fig-autocomplete");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add jkl init with interactive and non-interactive flows for hooks and skills
- add jkl init fig-autocomplete and migrate update/docs guidance to this command
- support Kiro agent config selection with configurable scan directory and explicit agent config targets
- mark jkl init as experimental via runtime warning
- remove helper-install behavior from install/uninstall paths while keeping the sync script in repo

## Validation
- cargo fmt --all
- cargo test --locked