### PR TITLE
fix(ci): package AL2 tarball from rust_target output

### DIFF
--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Package tarball
         run: |
           mkdir -p dist
-          tar -C "target/${{ matrix.target }}/release" \
+          tar -C "target/${{ matrix.rust_target || matrix.target }}/release" \
             -czf "dist/${{ matrix.asset }}" \
             "${{ env.BIN_NAME }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Package tarball
         run: |
           mkdir -p dist
-          tar -C "target/${{ matrix.target }}/release" \
+          tar -C "target/${{ matrix.rust_target || matrix.target }}/release" \
             -czf "dist/${{ matrix.asset }}" \
             "${{ env.BIN_NAME }}"
 


### PR DESCRIPTION
## Summary
- Fixes packaging path resolution for the `x86_64-unknown-linux-gnu.2.26` matrix target in release workflows.
- Uses `matrix.rust_target || matrix.target` when reading from `target/.../release` during tarball packaging.
- Applies the same one-line fix to both `release.yml` and `dev-preview.yml`.

## Error This Fix Addresses
Prerelease/release packaging fails with:

```text
tar: target/x86_64-unknown-linux-gnu.2.26/release: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2.
```

## Root Cause
For the AL2 job, the matrix target is `x86_64-unknown-linux-gnu.2.26` for `cargo zigbuild`, but the Rust output directory is keyed by the Rust target (`x86_64-unknown-linux-gnu`) because `rust_target` is set to that value.

Packaging previously read from:
- `target/${{ matrix.target }}/release`

So the tar step looked in a non-existent directory for the AL2 build.

## Fix
Packaging now reads from:
- `target/${{ matrix.rust_target || matrix.target }}/release`

This preserves behavior for all other targets and correctly resolves AL2 artifacts.

## Scope
- `.github/workflows/release.yml`
- `.github/workflows/dev-preview.yml`
