### PR TITLE
fix(tui): make pane switching deterministic across windows

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -110,13 +110,32 @@ pub fn switch_client(target: &str) -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn select_window(target: &str) -> Result<(), io::Error> {
+    let output = Command::new("tmux")
+        .args(["select-window", "-t", target])
+        .output()?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        debug!(
+            "tmux select-window failed target={} stderr={}",
+            target, message
+        );
+        return Err(io::Error::new(io::ErrorKind::Other, message));
+    }
+    debug!("tmux select-window target={}", target);
+    Ok(())
+}
+
 pub fn select_pane(target: &str) -> Result<(), io::Error> {
     let output = Command::new("tmux")
         .args(["select-pane", "-t", target])
         .output()?;
     if !output.status.success() {
         let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!("tmux select-pane failed target={} stderr={}", target, message);
+        debug!(
+            "tmux select-pane failed target={} stderr={}",
+            target, message
+        );
         return Err(io::Error::new(io::ErrorKind::Other, message));
     }
     debug!("tmux select-pane target={}", target);
@@ -157,6 +176,20 @@ case "$1" in
   switch-client)
     if [ "${TMUX_SWITCH_FAIL:-0}" -ne 0 ]; then
       echo "${TMUX_SWITCH_ERR:-error}" 1>&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  select-window)
+    if [ "${TMUX_SELECT_WINDOW_FAIL:-0}" -ne 0 ]; then
+      echo "${TMUX_SELECT_WINDOW_ERR:-error}" 1>&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  select-pane)
+    if [ "${TMUX_SELECT_PANE_FAIL:-0}" -ne 0 ]; then
+      echo "${TMUX_SELECT_PANE_ERR:-error}" 1>&2
       exit 1
     fi
     exit 0
@@ -274,5 +307,26 @@ esac
         let err = switch_client("@1").expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
         assert_eq!(err.to_string(), "no client");
+    }
+
+    #[test]
+    fn select_window_success() {
+        let mut env = EnvGuard::new("tmux-select-window-ok");
+        setup_fake_tmux(&mut env);
+        env.remove_var("TMUX_SELECT_WINDOW_FAIL");
+
+        select_window("@10").expect("select window");
+    }
+
+    #[test]
+    fn select_window_returns_error_on_failure() {
+        let mut env = EnvGuard::new("tmux-select-window-error");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_SELECT_WINDOW_FAIL", "1");
+        env.set_var("TMUX_SELECT_WINDOW_ERR", "no window");
+
+        let err = select_window("@10").expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "no window");
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -110,6 +110,19 @@ pub fn switch_client(target: &str) -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn select_pane(target: &str) -> Result<(), io::Error> {
+    let output = Command::new("tmux")
+        .args(["select-pane", "-t", target])
+        .output()?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        debug!("tmux select-pane failed target={} stderr={}", target, message);
+        return Err(io::Error::new(io::ErrorKind::Other, message));
+    }
+    debug!("tmux select-pane target={}", target);
+    Ok(())
+}
+
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -102,6 +102,8 @@ struct WindowRow {
 struct PaneRow {
     /// The pane ID
     id: String,
+    /// The tmux window ID containing this pane
+    window_id: String,
     /// Temporary name of a pane, likely to fall out of sync with the pane ID
     alias: Option<String>,
     /// The status of the pane
@@ -430,6 +432,8 @@ impl App {
                     info!("tui switching to session_id={}", window.session_id);
                     crate::tmux::switch_client(&window.session_id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::select_window(&window.id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
                 }
                 RowItem::Pane(pane) => {
                     info!(
@@ -437,6 +441,8 @@ impl App {
                         pane.id, pane.session_id
                     );
                     crate::tmux::switch_client(&pane.session_id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::select_window(&pane.window_id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
                     crate::tmux::select_pane(&pane.id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
@@ -922,6 +928,7 @@ fn build_sessions(
                             );
                             PaneRow {
                                 id: pane_id,
+                                window_id: window_id.clone(),
                                 alias: pane_alias,
                                 status: pane_status,
                                 context: pane_context_value,
@@ -1100,6 +1107,10 @@ target="${3:-}"
 case "$cmd" in
   switch-client)
     printf "switch-client:%s\n" "$target" >> "$log_file"
+    exit 0
+    ;;
+  select-window)
+    printf "select-window:%s\n" "$target" >> "$log_file"
     exit 0
     ;;
   select-pane)
@@ -1312,6 +1323,7 @@ esac
                 context: "wctx".to_string(),
                 panes: vec![PaneRow {
                     id: "%1".to_string(),
+                    window_id: "@10".to_string(),
                     alias: Some("verylongalias".to_string()),
                     status: None,
                     context: "p1".to_string(),
@@ -1345,6 +1357,7 @@ esac
                     panes: vec![
                         PaneRow {
                             id: "%1".to_string(),
+                            window_id: "@10".to_string(),
                             alias: None,
                             status: None,
                             context: "p1".to_string(),
@@ -1352,6 +1365,7 @@ esac
                         },
                         PaneRow {
                             id: "%2".to_string(),
+                            window_id: "@10".to_string(),
                             alias: None,
                             status: None,
                             context: "p2".to_string(),
@@ -1397,6 +1411,7 @@ esac
                 context: "wctx".to_string(),
                 panes: vec![PaneRow {
                     id: "%9".to_string(),
+                    window_id: "@10".to_string(),
                     alias: None,
                     status: None,
                     context: "pctx".to_string(),
@@ -1415,6 +1430,65 @@ esac
         app.switch_session().expect("switch");
 
         let log = fs::read_to_string(&log_path).expect("read log");
-        assert_eq!(log, "switch-client:@1\nselect-pane:%9\n");
+        assert_eq!(log, "switch-client:@1\nselect-window:@10\nselect-pane:%9\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn switch_session_on_pane_switches_to_target_window() {
+        let mut env = EnvGuard::new("tui-switch-pane-window-target");
+        setup_fake_tmux(&mut env);
+        let log_path = env.temp_dir().join("tmux.log");
+        env.set_var("TMUX_LOG_FILE", &log_path);
+
+        let sessions = vec![SessionRow {
+            id: "@1".to_string(),
+            name: "alpha".to_string(),
+            status: None,
+            context: "ctx".to_string(),
+            windows: vec![
+                WindowRow {
+                    id: "@10".to_string(),
+                    name: "editor".to_string(),
+                    status: None,
+                    context: "wctx1".to_string(),
+                    panes: vec![PaneRow {
+                        id: "%1".to_string(),
+                        window_id: "@10".to_string(),
+                        alias: None,
+                        status: None,
+                        context: "p1".to_string(),
+                        session_id: "@1".to_string(),
+                    }],
+                    session_id: "@1".to_string(),
+                },
+                WindowRow {
+                    id: "@20".to_string(),
+                    name: "server".to_string(),
+                    status: None,
+                    context: "wctx2".to_string(),
+                    panes: vec![PaneRow {
+                        id: "%9".to_string(),
+                        window_id: "@20".to_string(),
+                        alias: None,
+                        status: None,
+                        context: "p9".to_string(),
+                        session_id: "@1".to_string(),
+                    }],
+                    session_id: "@1".to_string(),
+                },
+            ],
+        }];
+
+        let mut app =
+            App::new_with_filter(sessions, Box::new(|_, _| Ok(String::new()))).expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+        app.state.select(Some(4));
+
+        app.switch_session().expect("switch");
+
+        let log = fs::read_to_string(&log_path).expect("read log");
+        assert_eq!(log, "switch-client:@1\nselect-window:@20\nselect-pane:%9\n");
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -102,8 +102,6 @@ struct WindowRow {
 struct PaneRow {
     /// The pane ID
     id: String,
-    /// The tmux window ID containing this pane
-    window_id: String,
     /// Temporary name of a pane, likely to fall out of sync with the pane ID
     alias: Option<String>,
     /// The status of the pane
@@ -442,7 +440,7 @@ impl App {
                     );
                     crate::tmux::switch_client(&pane.session_id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
-                    crate::tmux::select_window(&pane.window_id)
+                    crate::tmux::select_window(&pane.id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
                     crate::tmux::select_pane(&pane.id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
@@ -928,7 +926,6 @@ fn build_sessions(
                             );
                             PaneRow {
                                 id: pane_id,
-                                window_id: window_id.clone(),
                                 alias: pane_alias,
                                 status: pane_status,
                                 context: pane_context_value,
@@ -1323,7 +1320,6 @@ esac
                 context: "wctx".to_string(),
                 panes: vec![PaneRow {
                     id: "%1".to_string(),
-                    window_id: "@10".to_string(),
                     alias: Some("verylongalias".to_string()),
                     status: None,
                     context: "p1".to_string(),
@@ -1357,7 +1353,6 @@ esac
                     panes: vec![
                         PaneRow {
                             id: "%1".to_string(),
-                            window_id: "@10".to_string(),
                             alias: None,
                             status: None,
                             context: "p1".to_string(),
@@ -1365,7 +1360,6 @@ esac
                         },
                         PaneRow {
                             id: "%2".to_string(),
-                            window_id: "@10".to_string(),
                             alias: None,
                             status: None,
                             context: "p2".to_string(),
@@ -1411,7 +1405,6 @@ esac
                 context: "wctx".to_string(),
                 panes: vec![PaneRow {
                     id: "%9".to_string(),
-                    window_id: "@10".to_string(),
                     alias: None,
                     status: None,
                     context: "pctx".to_string(),
@@ -1430,7 +1423,7 @@ esac
         app.switch_session().expect("switch");
 
         let log = fs::read_to_string(&log_path).expect("read log");
-        assert_eq!(log, "switch-client:@1\nselect-window:@10\nselect-pane:%9\n");
+        assert_eq!(log, "switch-client:@1\nselect-window:%9\nselect-pane:%9\n");
     }
 
     #[test]
@@ -1454,7 +1447,6 @@ esac
                     context: "wctx1".to_string(),
                     panes: vec![PaneRow {
                         id: "%1".to_string(),
-                        window_id: "@10".to_string(),
                         alias: None,
                         status: None,
                         context: "p1".to_string(),
@@ -1469,7 +1461,6 @@ esac
                     context: "wctx2".to_string(),
                     panes: vec![PaneRow {
                         id: "%9".to_string(),
-                        window_id: "@20".to_string(),
                         alias: None,
                         status: None,
                         context: "p9".to_string(),
@@ -1489,6 +1480,6 @@ esac
         app.switch_session().expect("switch");
 
         let log = fs::read_to_string(&log_path).expect("read log");
-        assert_eq!(log, "switch-client:@1\nselect-window:@20\nselect-pane:%9\n");
+        assert_eq!(log, "switch-client:@1\nselect-window:%9\nselect-pane:%9\n");
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -420,14 +420,28 @@ impl App {
     /// Switches to the selected session or pane
     fn switch_session(&self) -> Result<(), TuiError> {
         if let Some(row) = self.selected_row() {
-            let target_session_id = match row {
-                RowItem::Session(session) => session.id.as_str(),
-                RowItem::Window(window) => window.session_id.as_str(),
-                RowItem::Pane(pane) => pane.session_id.as_str(),
-            };
-            info!("tui switching to session_id={}", target_session_id);
-            crate::tmux::switch_client(target_session_id)
-                .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+            match row {
+                RowItem::Session(session) => {
+                    info!("tui switching to session_id={}", session.id);
+                    crate::tmux::switch_client(&session.id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                }
+                RowItem::Window(window) => {
+                    info!("tui switching to session_id={}", window.session_id);
+                    crate::tmux::switch_client(&window.session_id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                }
+                RowItem::Pane(pane) => {
+                    info!(
+                        "tui switching to pane_id={} in session_id={}",
+                        pane.id, pane.session_id
+                    );
+                    crate::tmux::switch_client(&pane.session_id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::select_pane(&pane.id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                }
+            }
         }
         Ok(())
     }
@@ -1054,8 +1068,14 @@ fn status_style(status: Option<&crate::context::AgentStatus>) -> Style {
 mod tests {
     use super::*;
     use crate::context::{AgentStatus, PaneContext, SessionContext, WindowContext, session_key};
+    #[cfg(unix)]
+    use crate::test_utils::EnvGuard;
     use crate::tmux::{TmuxPane, TmuxSession};
     use std::collections::HashMap;
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     fn session_row(id: &str, name: &str) -> SessionRow {
         SessionRow {
@@ -1065,6 +1085,41 @@ mod tests {
             context: "ctx".to_string(),
             windows: Vec::new(),
         }
+    }
+
+    #[cfg(unix)]
+    fn setup_fake_tmux(env: &mut EnvGuard) {
+        let bin_dir = env.temp_dir().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let script_path = bin_dir.join("tmux");
+        let script = r#"#!/bin/sh
+set -eu
+log_file="${TMUX_LOG_FILE:?}"
+cmd="${1:-}"
+target="${3:-}"
+case "$cmd" in
+  switch-client)
+    printf "switch-client:%s\n" "$target" >> "$log_file"
+    exit 0
+    ;;
+  select-pane)
+    printf "select-pane:%s\n" "$target" >> "$log_file"
+    exit 0
+    ;;
+  *)
+    printf "unsupported:%s\n" "$cmd" >> "$log_file"
+    exit 1
+    ;;
+esac
+"#;
+        fs::write(&script_path, script).expect("write tmux script");
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod");
+
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{}", bin_dir.display(), old_path);
+        env.set_var("PATH", new_path);
     }
 
     #[test]
@@ -1320,5 +1375,46 @@ mod tests {
             RowItem::Session(row) => assert_eq!(row.id, "@2"),
             RowItem::Window(_) | RowItem::Pane(_) => panic!("expected session row"),
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn switch_session_on_pane_selects_target_pane() {
+        let mut env = EnvGuard::new("tui-switch-pane-target");
+        setup_fake_tmux(&mut env);
+        let log_path = env.temp_dir().join("tmux.log");
+        env.set_var("TMUX_LOG_FILE", &log_path);
+
+        let sessions = vec![SessionRow {
+            id: "@1".to_string(),
+            name: "alpha".to_string(),
+            status: None,
+            context: "ctx".to_string(),
+            windows: vec![WindowRow {
+                id: "@10".to_string(),
+                name: "editor".to_string(),
+                status: None,
+                context: "wctx".to_string(),
+                panes: vec![PaneRow {
+                    id: "%9".to_string(),
+                    alias: None,
+                    status: None,
+                    context: "pctx".to_string(),
+                    session_id: "@1".to_string(),
+                }],
+                session_id: "@1".to_string(),
+            }],
+        }];
+
+        let mut app =
+            App::new_with_filter(sessions, Box::new(|_, _| Ok(String::new()))).expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+        app.state.select(Some(2));
+
+        app.switch_session().expect("switch");
+
+        let log = fs::read_to_string(&log_path).expect("read log");
+        assert_eq!(log, "switch-client:@1\nselect-pane:%9\n");
     }
 }


### PR DESCRIPTION
## Summary
- switch pane navigation by resolving window target from pane id at execution time
- keep the switch flow as: switch-client -> select-window -> select-pane
- add and maintain regression coverage for pane selection across windows

## Testing
- cargo test --locked

Supersedes #33.