### PR TITLE
fix(tui): make pane switching deterministic across windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,4 +38,5 @@ Use this as the default playbook for coding agents in this repository.
 - Make minimal, targeted changes.
 - Preserve existing CLI behavior and keybindings unless requested.
 - Update docs when commands or behavior change.
-
+- Defer to runtime tmux values for targeting and navigation. Session/window/pane IDs can change after tmux resurrect or restart.
+- Treat persisted context IDs as advisory metadata. Re-resolve live IDs from tmux (`list-sessions`, `list-panes`, pane targets) before executing switch/select commands.

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -110,13 +110,32 @@ pub fn switch_client(target: &str) -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn select_window(target: &str) -> Result<(), io::Error> {
+    let output = Command::new("tmux")
+        .args(["select-window", "-t", target])
+        .output()?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        debug!(
+            "tmux select-window failed target={} stderr={}",
+            target, message
+        );
+        return Err(io::Error::new(io::ErrorKind::Other, message));
+    }
+    debug!("tmux select-window target={}", target);
+    Ok(())
+}
+
 pub fn select_pane(target: &str) -> Result<(), io::Error> {
     let output = Command::new("tmux")
         .args(["select-pane", "-t", target])
         .output()?;
     if !output.status.success() {
         let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!("tmux select-pane failed target={} stderr={}", target, message);
+        debug!(
+            "tmux select-pane failed target={} stderr={}",
+            target, message
+        );
         return Err(io::Error::new(io::ErrorKind::Other, message));
     }
     debug!("tmux select-pane target={}", target);
@@ -157,6 +176,20 @@ case "$1" in
   switch-client)
     if [ "${TMUX_SWITCH_FAIL:-0}" -ne 0 ]; then
       echo "${TMUX_SWITCH_ERR:-error}" 1>&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  select-window)
+    if [ "${TMUX_SELECT_WINDOW_FAIL:-0}" -ne 0 ]; then
+      echo "${TMUX_SELECT_WINDOW_ERR:-error}" 1>&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  select-pane)
+    if [ "${TMUX_SELECT_PANE_FAIL:-0}" -ne 0 ]; then
+      echo "${TMUX_SELECT_PANE_ERR:-error}" 1>&2
       exit 1
     fi
     exit 0
@@ -274,5 +307,26 @@ esac
         let err = switch_client("@1").expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
         assert_eq!(err.to_string(), "no client");
+    }
+
+    #[test]
+    fn select_window_success() {
+        let mut env = EnvGuard::new("tmux-select-window-ok");
+        setup_fake_tmux(&mut env);
+        env.remove_var("TMUX_SELECT_WINDOW_FAIL");
+
+        select_window("@10").expect("select window");
+    }
+
+    #[test]
+    fn select_window_returns_error_on_failure() {
+        let mut env = EnvGuard::new("tmux-select-window-error");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_SELECT_WINDOW_FAIL", "1");
+        env.set_var("TMUX_SELECT_WINDOW_ERR", "no window");
+
+        let err = select_window("@10").expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "no window");
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -430,6 +430,8 @@ impl App {
                     info!("tui switching to session_id={}", window.session_id);
                     crate::tmux::switch_client(&window.session_id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::select_window(&window.id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
                 }
                 RowItem::Pane(pane) => {
                     info!(
@@ -437,6 +439,8 @@ impl App {
                         pane.id, pane.session_id
                     );
                     crate::tmux::switch_client(&pane.session_id)
+                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::select_window(&pane.id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
                     crate::tmux::select_pane(&pane.id)
                         .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
@@ -1102,6 +1106,10 @@ case "$cmd" in
     printf "switch-client:%s\n" "$target" >> "$log_file"
     exit 0
     ;;
+  select-window)
+    printf "select-window:%s\n" "$target" >> "$log_file"
+    exit 0
+    ;;
   select-pane)
     printf "select-pane:%s\n" "$target" >> "$log_file"
     exit 0
@@ -1415,6 +1423,63 @@ esac
         app.switch_session().expect("switch");
 
         let log = fs::read_to_string(&log_path).expect("read log");
-        assert_eq!(log, "switch-client:@1\nselect-pane:%9\n");
+        assert_eq!(log, "switch-client:@1\nselect-window:%9\nselect-pane:%9\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn switch_session_on_pane_switches_to_target_window() {
+        let mut env = EnvGuard::new("tui-switch-pane-window-target");
+        setup_fake_tmux(&mut env);
+        let log_path = env.temp_dir().join("tmux.log");
+        env.set_var("TMUX_LOG_FILE", &log_path);
+
+        let sessions = vec![SessionRow {
+            id: "@1".to_string(),
+            name: "alpha".to_string(),
+            status: None,
+            context: "ctx".to_string(),
+            windows: vec![
+                WindowRow {
+                    id: "@10".to_string(),
+                    name: "editor".to_string(),
+                    status: None,
+                    context: "wctx1".to_string(),
+                    panes: vec![PaneRow {
+                        id: "%1".to_string(),
+                        alias: None,
+                        status: None,
+                        context: "p1".to_string(),
+                        session_id: "@1".to_string(),
+                    }],
+                    session_id: "@1".to_string(),
+                },
+                WindowRow {
+                    id: "@20".to_string(),
+                    name: "server".to_string(),
+                    status: None,
+                    context: "wctx2".to_string(),
+                    panes: vec![PaneRow {
+                        id: "%9".to_string(),
+                        alias: None,
+                        status: None,
+                        context: "p9".to_string(),
+                        session_id: "@1".to_string(),
+                    }],
+                    session_id: "@1".to_string(),
+                },
+            ],
+        }];
+
+        let mut app =
+            App::new_with_filter(sessions, Box::new(|_, _| Ok(String::new()))).expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+        app.state.select(Some(4));
+
+        app.switch_session().expect("switch");
+
+        let log = fs::read_to_string(&log_path).expect("read log");
+        assert_eq!(log, "switch-client:@1\nselect-window:%9\nselect-pane:%9\n");
     }
 }


### PR DESCRIPTION
## Summary
- make pane navigation use runtime tmux targets (session -> window-from-pane -> pane)
- add tmux select-window integration and related unit tests
- add/adjust TUI pane-switch regression tests
- update AGENTS.md guidance to defer to runtime tmux IDs after resurrect/restart

## Testing
- cargo fmt --all
- cargo test --locked

Supersedes #35 and #33.