### PR TITLE
Selection buffer session context

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -80,6 +80,25 @@ pub fn list_sessions() -> Result<Vec<TmuxSession>, io::Error> {
     Ok(sessions)
 }
 
+pub fn current_session_id() -> Result<String, io::Error> {
+    let output = Command::new("tmux")
+        .args(["display-message", "-p", "#{session_id}"])
+        .output()?;
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(io::Error::new(io::ErrorKind::Other, message));
+    }
+    let session_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if session_id.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "tmux returned empty current session id",
+        ));
+    }
+    debug!("tmux current session id={}", session_id);
+    Ok(session_id)
+}
+
 pub fn list_panes() -> Result<Vec<TmuxPane>, io::Error> {
     let output = Command::new("tmux")
         .args([
@@ -254,6 +273,14 @@ case "$1" in
     fi
     exit 0
     ;;
+  display-message)
+    if [ "${TMUX_DISPLAY_MESSAGE_EXIT:-0}" -ne 0 ]; then
+      echo "${TMUX_DISPLAY_MESSAGE_ERR:-error}" 1>&2
+      exit "${TMUX_DISPLAY_MESSAGE_EXIT}"
+    fi
+    printf "%s" "${TMUX_DISPLAY_MESSAGE:-}"
+    exit 0
+    ;;
   select-window)
     if [ "${TMUX_SELECT_WINDOW_FAIL:-0}" -ne 0 ]; then
       echo "${TMUX_SELECT_WINDOW_ERR:-error}" 1>&2
@@ -387,6 +414,41 @@ esac
         env.remove_var("TMUX_SWITCH_FAIL");
 
         switch_client("@1").expect("switch client");
+    }
+
+    #[test]
+    fn current_session_id_parses_output() {
+        let mut env = EnvGuard::new("tmux-current-session-id-ok");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_DISPLAY_MESSAGE", "@42\n");
+        env.remove_var("TMUX_DISPLAY_MESSAGE_EXIT");
+
+        let session_id = current_session_id().expect("current session id");
+        assert_eq!(session_id, "@42");
+    }
+
+    #[test]
+    fn current_session_id_returns_error_on_failure() {
+        let mut env = EnvGuard::new("tmux-current-session-id-error");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_DISPLAY_MESSAGE_EXIT", "1");
+        env.set_var("TMUX_DISPLAY_MESSAGE_ERR", "no current client");
+
+        let err = current_session_id().expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "no current client");
+    }
+
+    #[test]
+    fn current_session_id_returns_error_on_empty_output() {
+        let mut env = EnvGuard::new("tmux-current-session-id-empty");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_DISPLAY_MESSAGE", "");
+        env.remove_var("TMUX_DISPLAY_MESSAGE_EXIT");
+
+        let err = current_session_id().expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "tmux returned empty current session id");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -32,6 +32,13 @@ pub enum TuiError {
 
 pub fn run() -> Result<(), TuiError> {
     info!("tui starting");
+    let preferred_session_id = crate::tmux::current_session_id().ok();
+    if let Some(session_id) = preferred_session_id.as_ref() {
+        info!("tui current session id={session_id}");
+    } else {
+        debug!("tui current session id unavailable, defaulting selection to first row");
+    }
+
     let sessions =
         crate::tmux::list_sessions().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
     info!(
@@ -50,7 +57,7 @@ pub fn run() -> Result<(), TuiError> {
     let items = build_sessions(sessions, contexts, panes);
     info!("tui built {} session rows", items.len());
 
-    let mut app = App::new(items)?;
+    let mut app = App::new(items, preferred_session_id)?;
     let mut terminal = ratatui::init();
     let result = app.run(&mut terminal);
     ratatui::restore();
@@ -267,8 +274,15 @@ struct App<S: SessionSearch> {
 
 impl App<NucleoSessionSearch> {
     /// Creates a list view of sessions and panes
-    fn new(sessions: Vec<SessionRow>) -> Result<Self, TuiError> {
-        Self::new_with_filter(sessions, NucleoSessionSearch::new())
+    fn new(
+        sessions: Vec<SessionRow>,
+        preferred_session_id: Option<String>,
+    ) -> Result<Self, TuiError> {
+        Self::new_with_filter_and_preferred_session(
+            sessions,
+            preferred_session_id,
+            NucleoSessionSearch::new(),
+        )
     }
 }
 
@@ -277,6 +291,14 @@ impl<S: SessionSearch> App<S> {
     ///
     /// This keeps search behavior testable without heap allocation or dynamic dispatch.
     fn new_with_filter(sessions: Vec<SessionRow>, filter: S) -> Result<Self, TuiError> {
+        Self::new_with_filter_and_preferred_session(sessions, None, filter)
+    }
+
+    fn new_with_filter_and_preferred_session(
+        sessions: Vec<SessionRow>,
+        preferred_session_id: Option<String>,
+        filter: S,
+    ) -> Result<Self, TuiError> {
         let mut app = Self {
             state: TableState::default(),
             filtered_sessions: sessions.clone(),
@@ -295,6 +317,7 @@ impl<S: SessionSearch> App<S> {
             filter,
         };
         app.rebuild_rows();
+        app.select_preferred_session(preferred_session_id.as_deref());
         app.ensure_selection();
         Ok(app)
     }
@@ -410,6 +433,20 @@ impl<S: SessionSearch> App<S> {
             self.state.select(None);
         } else if self.state.selected().is_none() {
             self.state.select(Some(0));
+        }
+    }
+
+    fn select_preferred_session(&mut self, preferred_session_id: Option<&str>) {
+        let Some(preferred_session_id) = preferred_session_id else {
+            return;
+        };
+        if let Some(index) = self.rows.iter().position(|row| {
+            matches!(
+                row,
+                RowItem::Session(session) if session.id == preferred_session_id
+            )
+        }) {
+            self.state.select(Some(index));
         }
     }
 
@@ -1530,6 +1567,40 @@ esac
             .filter_ids("gma", &candidates)
             .expect("nucleo fuzzy search");
         assert_eq!(matches, vec!["@3".to_string()]);
+    }
+
+    #[test]
+    fn new_with_preferred_session_selects_matching_session() {
+        let sessions = vec![session_row("@1", "alpha"), session_row("@2", "beta")];
+        let app = App::new_with_filter_and_preferred_session(
+            sessions,
+            Some("@2".to_string()),
+            passthrough_filter(),
+        )
+        .expect("app");
+
+        let selected = app.selected_row().expect("selected row");
+        match selected {
+            RowItem::Session(row) => assert_eq!(row.id, "@2"),
+            RowItem::Window(_) | RowItem::Pane(_) => panic!("expected session row"),
+        }
+    }
+
+    #[test]
+    fn new_with_preferred_session_falls_back_to_first_row() {
+        let sessions = vec![session_row("@1", "alpha"), session_row("@2", "beta")];
+        let app = App::new_with_filter_and_preferred_session(
+            sessions,
+            Some("@404".to_string()),
+            passthrough_filter(),
+        )
+        .expect("app");
+
+        let selected = app.selected_row().expect("selected row");
+        match selected {
+            RowItem::Session(row) => assert_eq!(row.id, "@1"),
+            RowItem::Window(_) | RowItem::Pane(_) => panic!("expected session row"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Set the initial list view selection to the currently active tmux session.

This improves the user experience by maintaining context, ensuring the selection buffer defaults to the session the user navigated from rather than a generic position.

---
<p><a href="https://cursor.com/agents?id=bc-4e2ffa61-5cf2-433a-80ca-9a0745a334ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2ffa61-5cf2-433a-80ca-9a0745a334ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

