### PR TITLE
fix(tui): compact pane status selector popup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,4 @@ Use this as the default playbook for coding agents in this repository.
 - Update docs when commands or behavior change.
 - Defer to runtime tmux values for targeting and navigation. Session/window/pane IDs can change after tmux resurrect or restart.
 - Treat persisted context IDs as advisory metadata. Re-resolve live IDs from tmux (`list-sessions`, `list-panes`, pane targets) before executing switch/select commands.
+- Use conventional commit messages

--- a/jkl.tmux
+++ b/jkl.tmux
@@ -39,6 +39,6 @@ bind_prefix_key() {
 bind_prefix_key "@jkl_key_tui" "f" display-popup -E -w 40% -h 40% "jkl tui"
 bind_prefix_key "@jkl_key_context" "W" command-prompt -p "Context for #S:" "run-shell \"jkl upsert '#S' --session-id '#{session_id}' --context '%%'\""
 bind_prefix_key "@jkl_key_edit" "e" display-popup -E -w 40% -h 40% "nvim ~/.config/jkl/session_context.json"
-bind_prefix_key "@jkl_key_pane_state" "S" run-shell 'tmux display-popup -E -w 30% -h 30% "jkl tui --pane-state --session-name \"#{session_name}\" --pane-id \"#{pane_id}\""'
+bind_prefix_key "@jkl_key_pane_state" "S" run-shell 'tmux display-popup -E -w 30% -h 20% "jkl tui --pane-state --session-name \"#{session_name}\" --pane-id \"#{pane_id}\""'
 
 tmux set-hook -g session-renamed "run-shell \"jkl rename '#{hook_session}' '#{hook_session_name}'\""

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@ use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap};
 use ratatui::{DefaultTerminal, Frame};
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -938,14 +938,14 @@ impl PaneSelector {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         return Ok(());
                     }
-                    KeyCode::Left | KeyCode::Char('h') => {
+                    KeyCode::Left | KeyCode::Up | KeyCode::Char('h') | KeyCode::Char('k') => {
                         if self.selected == 0 {
                             self.selected = self.options.len() - 1;
                         } else {
                             self.selected -= 1;
                         }
                     }
-                    KeyCode::Right | KeyCode::Char('l') => {
+                    KeyCode::Right | KeyCode::Down | KeyCode::Char('l') | KeyCode::Char('j') => {
                         self.selected = (self.selected + 1) % self.options.len();
                     }
                     KeyCode::Enter => {
@@ -974,7 +974,20 @@ impl PaneSelector {
 
     /// Draw the pane selector UI
     fn draw(&self, frame: &mut Frame) {
-        let area = centered_rect(60, 20, frame.area());
+        let popup_area = frame.area();
+        let pane_title = format!("Pane {}", self.pane_id);
+        let options_line_width: u16 = self
+            .options
+            .iter()
+            .map(|(label, _)| (UnicodeWidthStr::width(label.as_str()) + 2) as u16)
+            .sum();
+        let title_width = UnicodeWidthStr::width(pane_title.as_str()) as u16;
+        let required_inner_width = options_line_width.max(title_width).max(1);
+        let available_inner_width = popup_area.width.max(1);
+        let wrapped_lines = required_inner_width.div_ceil(available_inner_width).max(1);
+        let selector_width = required_inner_width.min(popup_area.width).max(1);
+        let selector_height = (wrapped_lines + 1).min(popup_area.height).max(1);
+        let area = centered_rect_size(selector_width, selector_height, popup_area);
         let spans = self
             .options
             .iter()
@@ -988,13 +1001,12 @@ impl PaneSelector {
                 Span::styled(format!(" {label} "), style)
             })
             .collect::<Vec<_>>();
-        let line = Line::from(spans);
-        let pane_title = format!("Pane {}", self.pane_id);
-        let paragraph = Paragraph::new(line)
+        let text = Text::from(vec![Line::from(pane_title), Line::from(spans)]);
+        let paragraph = Paragraph::new(text)
             .alignment(Alignment::Center)
-            .block(Block::default().borders(Borders::ALL).title(pane_title));
+            .wrap(Wrap { trim: true });
 
-        frame.render_widget(Clear, area);
+        frame.render_widget(Clear, popup_area);
         frame.render_widget(paragraph, area);
     }
 }
@@ -1037,20 +1049,12 @@ fn current_pane_status(
     }))
 }
 
-fn centered_rect(percent_x: u16, percent_y: u16, rect: Rect) -> Rect {
-    let vertical = Layout::vertical([
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-    ])
-    .split(rect);
-    let horizontal = Layout::horizontal([
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-    ])
-    .split(vertical[1]);
-    horizontal[1]
+fn centered_rect_size(width: u16, height: u16, rect: Rect) -> Rect {
+    let width = width.min(rect.width);
+    let height = height.min(rect.height);
+    let x = rect.x + rect.width.saturating_sub(width) / 2;
+    let y = rect.y + rect.height.saturating_sub(height) / 2;
+    Rect::new(x, y, width, height)
 }
 
 fn build_search_candidates(sessions: &[SessionRow]) -> Vec<SearchCandidate> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use self_update::backends::github::ReleaseList;
-use self_update::update::{Release, ReleaseAsset};
+use self_update::update::Release;
 use std::fs;
 
 const REPO_OWNER: &str = "cruzluna";
@@ -219,6 +219,7 @@ pub fn run(channel: UpdateChannel) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use self_update::update::ReleaseAsset;
 
     fn release(version: &str) -> Release {
         Release {


### PR DESCRIPTION
## Summary
- fix pane status selector rendering so it sizes to content instead of forcing a large inner area
- remove the inner selector border and keep only popup-level chrome
- tune default tmux keybinding popup size for `S` to `30% x 20%`
- scope `ReleaseAsset` import to tests in `src/update.rs` to avoid unused import warnings
- add AGENTS guidance to use conventional commit messages

## Testing
- cargo test --locked

Closes #53
