### PR TITLE
fix: streamline cli error reporting and logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,40 @@ mod tui;
 mod uninstall;
 mod update;
 
-fn main() -> Result<(), anyhow::Error> {
-    let log_path = init_logging()?;
-    log::info!("logging initialized to: {}", log_path.display());
-    cli::run()
+const LOG_SYMLINK_FILENAME: &str = "jkl.log";
+const ISSUE_INSTRUCTIONS: &str =
+    "Submit issues to github.com/cruzluna/jkl-2/issues and attach logs.";
+const UNKNOWN_ERROR_MESSAGE: &str = "unknown error (see log for details)";
+
+fn main() {
+    if let Err(error) = run_with_logging() {
+        eprintln!("Error: {}", error.user_message);
+        if let Some(log_path) = &error.log_path {
+            eprintln!("Details written to: {}", log_path.display());
+        } else {
+            eprintln!("Detailed logging unavailable: logging could not be initialized.");
+        }
+        eprintln!("{ISSUE_INSTRUCTIONS}");
+        std::process::exit(1);
+    }
 }
 
-fn init_logging() -> Result<std::path::PathBuf, anyhow::Error> {
+fn run_with_logging() -> Result<(), MainError> {
+    // Keep the handle alive until the command finishes so file logging stays active.
+    let (log_path, _logger_handle) = init_logging().map_err(MainError::logging_init)?;
+    log::info!("logging initialized to: {}", log_path.display());
+    match cli::run() {
+        Ok(()) => Ok(()),
+        Err(source) => {
+            let messages = normalized_error_messages(&source);
+            let user_message = display_message(&messages, true);
+            log_command_failure(&source, &messages, &user_message, &log_path);
+            Err(MainError::command_failed(user_message, log_path))
+        }
+    }
+}
+
+fn init_logging() -> Result<(std::path::PathBuf, flexi_logger::LoggerHandle), anyhow::Error> {
     use flexi_logger::{Cleanup, Criterion, FileSpec, Logger, Naming};
 
     let home_dir = std::env::var("HOME")?;
@@ -30,8 +57,12 @@ fn init_logging() -> Result<std::path::PathBuf, anyhow::Error> {
         .basename("jkl")
         .suffix("log");
 
-    Logger::try_with_str("debug")?
+    let logger_handle = Logger::try_with_str("debug")?
         .log_to_file(file_spec)
+        .append()
+        // flexi_logger keeps its rotated "current" file under an internal infix;
+        // expose a stable user-facing path alongside it.
+        .create_symlink(log_directory.join(LOG_SYMLINK_FILENAME))
         .rotate(
             Criterion::Size(50 * 1024 * 1024),
             Naming::Timestamps,
@@ -39,5 +70,126 @@ fn init_logging() -> Result<std::path::PathBuf, anyhow::Error> {
         )
         .start()?;
 
-    Ok(log_directory.join("jkl.log"))
+    Ok((stable_log_path(&log_directory), logger_handle))
+}
+
+fn stable_log_path(log_directory: &std::path::Path) -> std::path::PathBuf {
+    log_directory.join(LOG_SYMLINK_FILENAME)
+}
+
+fn normalized_error_messages(error: &anyhow::Error) -> Vec<String> {
+    error
+        .chain()
+        .map(|cause| cause.to_string())
+        .map(|message| message.trim().to_string())
+        .filter(|message| !message.is_empty())
+        .collect()
+}
+
+fn display_message(messages: &[String], has_log_path: bool) -> String {
+    messages.first().cloned().unwrap_or_else(|| {
+        if has_log_path {
+            UNKNOWN_ERROR_MESSAGE.to_string()
+        } else {
+            "unknown error".to_string()
+        }
+    })
+}
+
+fn log_command_failure(
+    error: &anyhow::Error,
+    messages: &[String],
+    user_message: &str,
+    log_path: &std::path::Path,
+) {
+    log::error!(
+        "command failed user_message={} log_file={}",
+        user_message,
+        log_path.display()
+    );
+
+    if messages.is_empty() {
+        log::error!("cause[0]: {UNKNOWN_ERROR_MESSAGE}");
+        log::debug!("command error chain={UNKNOWN_ERROR_MESSAGE}");
+    } else {
+        for (index, message) in messages.iter().enumerate() {
+            log::error!("cause[{index}]: {message}");
+        }
+        log::debug!("command error chain={}", messages.join(" -> "));
+    }
+
+    log::debug!("command error debug={:?}", error);
+}
+
+struct MainError {
+    user_message: String,
+    log_path: Option<std::path::PathBuf>,
+}
+
+impl MainError {
+    fn logging_init(source: anyhow::Error) -> Self {
+        let messages = normalized_error_messages(&source);
+        Self {
+            user_message: display_message(&messages, false),
+            log_path: None,
+        }
+    }
+
+    fn command_failed(user_message: String, log_path: std::path::PathBuf) -> Self {
+        Self {
+            user_message,
+            log_path: Some(log_path),
+        }
+    }
+}
+
+impl std::fmt::Display for MainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.user_message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MainError, UNKNOWN_ERROR_MESSAGE, display_message, normalized_error_messages};
+    use anyhow::Context;
+
+    #[test]
+    fn normalized_error_messages_skip_blank_context_and_trim_output() {
+        let source = Err::<(), _>(anyhow::anyhow!("boom"))
+            .context("   ")
+            .unwrap_err();
+        let messages = normalized_error_messages(&source);
+
+        assert_eq!(messages, vec!["boom".to_string()]);
+        assert_eq!(display_message(&messages, true), "boom");
+    }
+
+    #[test]
+    fn normalized_error_messages_preserve_order_for_display() {
+        let source = Err::<(), _>(anyhow::anyhow!("boom"))
+            .context("  outer failure  ")
+            .unwrap_err();
+        let messages = normalized_error_messages(&source);
+
+        assert_eq!(
+            messages,
+            vec!["outer failure".to_string(), "boom".to_string()]
+        );
+        assert_eq!(display_message(&messages, true), "outer failure");
+    }
+
+    #[test]
+    fn display_message_uses_log_aware_fallbacks() {
+        let messages = Vec::new();
+        assert_eq!(display_message(&messages, true), UNKNOWN_ERROR_MESSAGE);
+        assert_eq!(display_message(&messages, false), "unknown error");
+    }
+
+    #[test]
+    fn logging_init_uses_plain_fallback_without_log_path() {
+        let error = MainError::logging_init(anyhow::anyhow!("   "));
+        assert_eq!(error.user_message, "unknown error");
+        assert!(error.log_path.is_none());
+    }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -25,6 +25,24 @@ fn parse_tmux_timestamp(value: Option<&str>) -> u64 {
         .unwrap_or(0)
 }
 
+fn format_exit_status(status: std::process::ExitStatus) -> String {
+    status
+        .code()
+        .map(|code| format!("exit code {code}"))
+        .unwrap_or_else(|| status.to_string())
+}
+
+fn tmux_status_error(action: &str, status: std::process::ExitStatus, stderr: &[u8]) -> io::Error {
+    let status = format_exit_status(status);
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    let message = if stderr.is_empty() {
+        format!("tmux {action} failed ({status}) with empty stderr")
+    } else {
+        format!("tmux {action} failed ({status}): {stderr}")
+    };
+    io::Error::other(message)
+}
+
 pub fn list_sessions() -> Result<Vec<TmuxSession>, io::Error> {
     let output = Command::new("tmux")
         .args([
@@ -34,8 +52,9 @@ pub fn list_sessions() -> Result<Vec<TmuxSession>, io::Error> {
         ])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("list-sessions", output.status, &output.stderr);
+        debug!("tmux list-sessions failed error={err}");
+        return Err(err);
     }
     let raw_output = String::from_utf8_lossy(&output.stdout);
     debug!("tmux list-sessions raw output:\n{}", raw_output);
@@ -90,8 +109,9 @@ pub fn list_panes() -> Result<Vec<TmuxPane>, io::Error> {
         ])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("list-panes", output.status, &output.stderr);
+        debug!("tmux list-panes failed error={err}");
+        return Err(err);
     }
     let raw_output = String::from_utf8_lossy(&output.stdout);
     debug!("tmux list-panes raw output:\n{}", raw_output);
@@ -132,8 +152,9 @@ pub fn switch_client(target: &str) -> Result<(), io::Error> {
         .args(["switch-client", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("switch-client", output.status, &output.stderr);
+        debug!("tmux switch-client failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux switch-client target={}", target);
     Ok(())
@@ -144,12 +165,9 @@ pub fn select_window(target: &str) -> Result<(), io::Error> {
         .args(["select-window", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!(
-            "tmux select-window failed target={} stderr={}",
-            target, message
-        );
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("select-window", output.status, &output.stderr);
+        debug!("tmux select-window failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux select-window target={}", target);
     Ok(())
@@ -160,12 +178,9 @@ pub fn select_pane(target: &str) -> Result<(), io::Error> {
         .args(["select-pane", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!(
-            "tmux select-pane failed target={} stderr={}",
-            target, message
-        );
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("select-pane", output.status, &output.stderr);
+        debug!("tmux select-pane failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux select-pane target={}", target);
     Ok(())
@@ -176,12 +191,9 @@ pub fn kill_session(target: &str) -> Result<(), io::Error> {
         .args(["kill-session", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!(
-            "tmux kill-session failed target={} stderr={}",
-            target, message
-        );
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("kill-session", output.status, &output.stderr);
+        debug!("tmux kill-session failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux kill-session target={}", target);
     Ok(())
@@ -192,12 +204,9 @@ pub fn kill_window(target: &str) -> Result<(), io::Error> {
         .args(["kill-window", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!(
-            "tmux kill-window failed target={} stderr={}",
-            target, message
-        );
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("kill-window", output.status, &output.stderr);
+        debug!("tmux kill-window failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux kill-window target={}", target);
     Ok(())
@@ -208,9 +217,9 @@ pub fn kill_pane(target: &str) -> Result<(), io::Error> {
         .args(["kill-pane", "-t", target])
         .output()?;
     if !output.status.success() {
-        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug!("tmux kill-pane failed target={} stderr={}", target, message);
-        return Err(io::Error::new(io::ErrorKind::Other, message));
+        let err = tmux_status_error("kill-pane", output.status, &output.stderr);
+        debug!("tmux kill-pane failed target={target} error={err}");
+        return Err(err);
     }
     debug!("tmux kill-pane target={}", target);
     Ok(())
@@ -343,9 +352,26 @@ esac
 
         let err = list_sessions().expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "boom");
+        assert_eq!(
+            err.to_string(),
+            "tmux list-sessions failed (exit code 1): boom"
+        );
     }
 
+    #[test]
+    fn list_sessions_returns_error_when_stderr_is_empty() {
+        let mut env = EnvGuard::new("tmux-list-sessions-empty-stderr");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_LIST_SESSIONS_EXIT", "1");
+        env.set_var("TMUX_LIST_SESSIONS_ERR", " ");
+
+        let err = list_sessions().expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(
+            err.to_string(),
+            "tmux list-sessions failed (exit code 1) with empty stderr"
+        );
+    }
     #[test]
     fn list_panes_parses_output() {
         let mut env = EnvGuard::new("tmux-list-panes");
@@ -377,7 +403,10 @@ esac
 
         let err = list_panes().expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "no panes");
+        assert_eq!(
+            err.to_string(),
+            "tmux list-panes failed (exit code 1): no panes"
+        );
     }
 
     #[test]
@@ -398,7 +427,10 @@ esac
 
         let err = switch_client("@1").expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "no client");
+        assert_eq!(
+            err.to_string(),
+            "tmux switch-client failed (exit code 1): no client"
+        );
     }
 
     #[test]
@@ -419,6 +451,9 @@ esac
 
         let err = select_window("@10").expect_err("expected error");
         assert_eq!(err.kind(), io::ErrorKind::Other);
-        assert_eq!(err.to_string(), "no window");
+        assert_eq!(
+            err.to_string(),
+            "tmux select-window failed (exit code 1): no window"
+        );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -30,21 +30,36 @@ pub enum TuiError {
     TerminalIo(#[from] io::Error),
 }
 
+fn backend_failure(source: impl std::fmt::Display) -> TuiError {
+    let message = source.to_string();
+    error!("tui backend failure: {message}");
+    TuiError::BackendFailure(message)
+}
+
+fn context_resolution_failure(source: impl std::fmt::Display) -> TuiError {
+    let message = source.to_string();
+    error!("tui context resolution failure: {message}");
+    TuiError::ContextResolutionFailure(message)
+}
+
+fn search_failure(message: String) -> TuiError {
+    error!("tui search failure: {message}");
+    TuiError::SearchFailure(message)
+}
+
 pub fn run() -> Result<(), TuiError> {
     info!("tui starting");
-    let sessions =
-        crate::tmux::list_sessions().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+    let sessions = crate::tmux::list_sessions().map_err(backend_failure)?;
     info!(
         "tui loaded {} tmux sessions: {:?}",
         sessions.len(),
         sessions
     );
 
-    let contexts = crate::context::load_contexts()
-        .map_err(|e| TuiError::ContextResolutionFailure(e.to_string()))?;
+    let contexts = crate::context::load_contexts().map_err(context_resolution_failure)?;
     info!("tui loaded {} contexts", contexts.len());
 
-    let panes = crate::tmux::list_panes().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+    let panes = crate::tmux::list_panes().map_err(backend_failure)?;
     info!("tui loaded {} panes", panes.len());
 
     let items = build_sessions(sessions, contexts, panes);
@@ -229,8 +244,7 @@ impl SessionSearch for NucleoSessionSearch {
             let message = format!(
                 "search query exceeds matcher length limit ({query_codepoints} code points)"
             );
-            error!("{message}");
-            return Err(TuiError::SearchFailure(message));
+            return Err(search_failure(message));
         }
 
         if let Some(too_long) = candidates
@@ -241,8 +255,7 @@ impl SessionSearch for NucleoSessionSearch {
                 "search candidate {} exceeds matcher length limit",
                 too_long.id
             );
-            error!("{message}");
-            return Err(TuiError::SearchFailure(message));
+            return Err(search_failure(message));
         }
 
         let pattern = Pattern::parse(query, CaseMatching::Smart, Normalization::Smart);
@@ -517,27 +530,21 @@ impl<S: SessionSearch> App<S> {
             match row {
                 RowItem::Session(session) => {
                     info!("tui switching to session_id={}", session.id);
-                    crate::tmux::switch_client(&session.id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::switch_client(&session.id).map_err(backend_failure)?;
                 }
                 RowItem::Window(window) => {
                     info!("tui switching to session_id={}", window.session_id);
-                    crate::tmux::switch_client(&window.session_id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
-                    crate::tmux::select_window(&window.id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::switch_client(&window.session_id).map_err(backend_failure)?;
+                    crate::tmux::select_window(&window.id).map_err(backend_failure)?;
                 }
                 RowItem::Pane(pane) => {
                     info!(
                         "tui switching to pane_id={} in session_id={} window_id={}",
                         pane.id, pane.session_id, pane.window_id
                     );
-                    crate::tmux::switch_client(&pane.session_id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
-                    crate::tmux::select_window(&pane.window_id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
-                    crate::tmux::select_pane(&pane.id)
-                        .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                    crate::tmux::switch_client(&pane.session_id).map_err(backend_failure)?;
+                    crate::tmux::select_window(&pane.window_id).map_err(backend_failure)?;
+                    crate::tmux::select_pane(&pane.id).map_err(backend_failure)?;
                 }
             }
         }
@@ -572,18 +579,15 @@ impl<S: SessionSearch> App<S> {
         match target {
             RowKey::Session(session_id) => {
                 info!("tui deleting session_id={}", session_id);
-                crate::tmux::kill_session(session_id)
-                    .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                crate::tmux::kill_session(session_id).map_err(backend_failure)?;
             }
             RowKey::Window { window_id, .. } => {
                 info!("tui deleting window_id={}", window_id);
-                crate::tmux::kill_window(window_id)
-                    .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                crate::tmux::kill_window(window_id).map_err(backend_failure)?;
             }
             RowKey::Pane { pane_id, .. } => {
                 info!("tui deleting pane_id={}", pane_id);
-                crate::tmux::kill_pane(pane_id)
-                    .map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+                crate::tmux::kill_pane(pane_id).map_err(backend_failure)?;
             }
         }
         self.reload_data()?;
@@ -636,11 +640,9 @@ impl<S: SessionSearch> App<S> {
     }
 
     fn refresh_panes(&mut self) -> Result<(), TuiError> {
-        let live_panes =
-            crate::tmux::list_panes().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+        let live_panes = crate::tmux::list_panes().map_err(backend_failure)?;
         let live_map = collect_live_panes(&live_panes);
-        crate::context::prune_panes(&live_map)
-            .map_err(|e| TuiError::ContextResolutionFailure(e.to_string()))?;
+        crate::context::prune_panes(&live_map).map_err(context_resolution_failure)?;
         self.reload_data()?;
         Ok(())
     }
@@ -649,16 +651,13 @@ impl<S: SessionSearch> App<S> {
         info!("tui reload_data starting");
         let previous = self.selected_key();
 
-        let sessions =
-            crate::tmux::list_sessions().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+        let sessions = crate::tmux::list_sessions().map_err(backend_failure)?;
         info!("reload: loaded {} tmux sessions", sessions.len());
 
-        let contexts = crate::context::load_contexts()
-            .map_err(|e| TuiError::ContextResolutionFailure(e.to_string()))?;
+        let contexts = crate::context::load_contexts().map_err(context_resolution_failure)?;
         info!("reload: loaded {} contexts", contexts.len());
 
-        let panes =
-            crate::tmux::list_panes().map_err(|e| TuiError::BackendFailure(e.to_string()))?;
+        let panes = crate::tmux::list_panes().map_err(backend_failure)?;
         info!("reload: loaded {} panes", panes.len());
 
         self.sessions = build_sessions(sessions, contexts, panes);
@@ -962,7 +961,7 @@ impl PaneSelector {
                                 status,
                                 None,
                             )
-                            .map_err(|e| TuiError::ContextResolutionFailure(e.to_string()))?;
+                            .map_err(context_resolution_failure)?;
                         }
                         return Ok(());
                     }
@@ -1030,8 +1029,7 @@ fn current_pane_status(
     pane_id: &str,
     session_name: Option<&str>,
 ) -> Result<Option<crate::context::AgentStatus>, TuiError> {
-    let contexts = crate::context::load_contexts()
-        .map_err(|e| TuiError::ContextResolutionFailure(e.to_string()))?;
+    let contexts = crate::context::load_contexts().map_err(context_resolution_failure)?;
 
     if let Some(session_name) = session_name {
         return Ok(contexts
@@ -1929,5 +1927,22 @@ esac
 
         let log = fs::read_to_string(&log_path).expect("read log");
         assert_eq!(log, "switch-client:@1\nselect-window:@20\nselect-pane:%9\n");
+    }
+    #[test]
+    fn backend_failure_preserves_message() {
+        let error = backend_failure("boom");
+        assert_eq!(error.to_string(), "boom");
+    }
+
+    #[test]
+    fn context_resolution_failure_preserves_message() {
+        let error = context_resolution_failure("failed to load contexts");
+        assert_eq!(error.to_string(), "failed to load contexts");
+    }
+
+    #[test]
+    fn search_failure_preserves_message() {
+        let error = search_failure("query too long".to_string());
+        assert_eq!(error.to_string(), "Search failure: query too long");
     }
 }


### PR DESCRIPTION
## Summary
- improve top-level CLI error reporting while keeping detailed cause chains in the log
- keep a stable user-facing log path via ~/.config/jkl/jkl.log and append across runs to reduce log churn
- make tmux and TUI failures log clearer messages without extra normalization behavior in the TUI

## Testing
- cargo fmt --all
- cargo test --locked