### PR TITLE
Jkl prompt examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Each archive should contain the `jkl` binary at the top level.
 - Interactive integration setup: `jkl init`
 - Non-interactive hooks setup: `jkl init hooks --tool <claude|cursor|kiro> --scope <local|global> --non-interactive [--agent-config-dir <dir> (kiro only)] [--agent-config <path...> (kiro/cursor)]`
 - Non-interactive skills setup: `jkl init skills --tool <codex|claude|kiro> --scope <local|global> --non-interactive`
-- Non-interactive copy/paste prompts: `jkl init prompts [--provider <claude|codex|cursor|kiro>] [--option <hooks|skills|AGENTS.md|tmux.conf>]`
+- Non-interactive copy/paste prompts: `jkl init prompts [--provider <claude|codex|cursor|kiro>] [--option <hooks|skills|AGENTS.md|tmux.conf|examples>]`
 - Refresh Fig autocomplete: `jkl init fig-autocomplete`
 - Uninstall binary from current location: `jkl uninstall [--purge-data]`
 - Pane status selector: `jkl tui --pane-state --session-name <session_name...> --pane-id <pane_id>`
@@ -367,7 +367,7 @@ Codex skill paths:
 
 ### Copy/paste prompts
 
-Print the same copy/paste prompts shown by the installer and `jkl update`:
+Print the same copy/paste prompts shown by the installer and `jkl update`, plus common runnable `jkl` usage examples for agents:
 
 ```
 jkl init prompts
@@ -380,6 +380,7 @@ jkl init prompts --provider claude --option hooks
 jkl init prompts --provider codex --option skills
 jkl init prompts --option AGENTS.md
 jkl init prompts --option tmux.conf
+jkl init prompts --option examples
 ```
 
 ### Fig autocomplete

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -34,6 +34,7 @@ const initPromptOptionSuggestions: Fig.Suggestion[] = [
   { name: "skills", description: "Skill prompts" },
   { name: "AGENTS.md", description: "AGENTS.md prompt" },
   { name: "tmux.conf", description: "tmux.conf prompt" },
+  { name: "examples", description: "Common jkl usage examples" },
 ];
 
 const sessionNameGenerator: Fig.Generator = {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -615,4 +615,20 @@ esac
             _ => panic!("expected init prompts command"),
         }
     }
+
+    #[test]
+    fn parse_init_prompts_accepts_examples_value() {
+        let cli = Cli::try_parse_from(["jkl", "init", "prompts", "--option", "examples"])
+            .expect("parse init prompts");
+
+        match cli.command {
+            Commands::Init(InitArgs {
+                command: Some(InitCommands::Prompts(cmd)),
+            }) => {
+                assert_eq!(cmd.provider, None);
+                assert_eq!(cmd.option, Some(InitPromptOption::Examples));
+            }
+            _ => panic!("expected init prompts command"),
+        }
+    }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -26,6 +26,15 @@ const TMUX_CONF_LINES: [&str; 3] = [
     "set -g @jkl_force_bind_keys 'on'",
     "run '~/.tmux/plugins/tpm/tpm'",
 ];
+const PROMPT_USAGE_EXAMPLE_LINES: [&str; 7] = [
+    "Common jkl commands agents can run directly:",
+    "- Open the TUI: `jkl tui`",
+    "- Update current pane status: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working`",
+    "- Update current pane context: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --context \"triage auth bug\"`",
+    "- Update current session status + context: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --status waiting --context \"need review\"`",
+    "- Rename current session metadata entry: `jkl rename \"$(tmux display-message -p '#{session_id}')\" \"new session name\"`",
+    "- Remove stale metadata: `jkl sync`",
+];
 const AGENTS_MD_APPEND_LINES: [&str; 10] = [
     "## jkl",
     "- When working inside tmux, use `jkl upsert` to keep jkl metadata current.",
@@ -94,6 +103,8 @@ pub enum InitPromptOption {
     AgentsMd,
     #[value(name = "tmux.conf", alias = "tmux-conf", alias = "tmux_conf")]
     TmuxConf,
+    #[value(alias = "example", alias = "usage")]
+    Examples,
 }
 
 impl fmt::Display for InitPromptOption {
@@ -103,6 +114,7 @@ impl fmt::Display for InitPromptOption {
             Self::Skills => write!(f, "skills"),
             Self::AgentsMd => write!(f, "AGENTS.md"),
             Self::TmuxConf => write!(f, "tmux.conf"),
+            Self::Examples => write!(f, "examples"),
         }
     }
 }
@@ -285,6 +297,7 @@ fn render_prompts(provider: Option<InitTool>, option: Option<InitPromptOption>) 
             InitPromptOption::Skills,
             InitPromptOption::AgentsMd,
             InitPromptOption::TmuxConf,
+            InitPromptOption::Examples,
         ]
     });
 
@@ -315,6 +328,12 @@ fn render_prompts(provider: Option<InitTool>, option: Option<InitPromptOption>) 
                     .unwrap_or_else(|| ALL_PROMPT_TOOLS.to_vec());
                 sections.push(render_tmux_prompt(&tools));
             }
+            InitPromptOption::Examples => {
+                let tools = provider
+                    .map(|tool| vec![tool])
+                    .unwrap_or_else(|| ALL_PROMPT_TOOLS.to_vec());
+                sections.push(render_examples_prompt(&tools));
+            }
         }
     }
 
@@ -325,7 +344,9 @@ fn provider_supports_prompt_option(provider: InitTool, option: InitPromptOption)
     match option {
         InitPromptOption::Hooks => HOOK_PROMPT_TOOLS.contains(&provider),
         InitPromptOption::Skills => SKILL_PROMPT_TOOLS.contains(&provider),
-        InitPromptOption::AgentsMd | InitPromptOption::TmuxConf => true,
+        InitPromptOption::AgentsMd | InitPromptOption::TmuxConf | InitPromptOption::Examples => {
+            true
+        }
     }
 }
 
@@ -402,6 +423,14 @@ fn render_tmux_prompt(tools: &[InitTool]) -> String {
             .collect::<Vec<_>>()
             .join("\n"),
         "tmux run-shell \"~/.tmux/plugins/tpm/bin/install_plugins\""
+    )
+}
+
+fn render_examples_prompt(tools: &[InitTool]) -> String {
+    format!(
+        "Examples\n\nProviders: {}\n{}",
+        render_tool_list(tools),
+        PROMPT_USAGE_EXAMPLE_LINES.join("\n")
     )
 }
 
@@ -1218,7 +1247,19 @@ mod tests {
         assert!(rendered.contains("Skills"));
         assert!(rendered.contains("AGENTS.md"));
         assert!(rendered.contains("tmux.conf"));
+        assert!(rendered.contains("Examples"));
+        assert!(rendered.contains("jkl upsert"));
         assert!(!rendered.contains("Hooks"));
+    }
+
+    #[test]
+    fn render_examples_prompt_includes_live_tmux_identifiers() {
+        let rendered = render_prompts(Some(InitTool::Cursor), Some(InitPromptOption::Examples))
+            .expect("render prompts");
+        assert!(rendered.starts_with("Examples"));
+        assert!(rendered.contains("Providers: Cursor"));
+        assert!(rendered.contains("$(tmux display-message -p '#{pane_id}')"));
+        assert!(rendered.contains("jkl sync"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `examples` option to `jkl init prompts` to show common usage examples.

This provides agents with clear guidance on how to execute `jkl` commands, including live tmux identifiers, and is now included in the default `init prompts` output.

---
<p><a href="https://cursor.com/agents/bc-e41cfc64-9093-44af-b905-7d7d5e2d515a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e41cfc64-9093-44af-b905-7d7d5e2d515a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->