### PR TITLE
Live pane preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Each archive should contain the `jkl` binary at the top level.
 - Navigate rows: `↑`/`↓` or `j`/`k`
 - Expand/collapse selected session details (windows + panes): `l`/`h`
 - Toggle all session details (expand-all / collapse-all): `L`
+- Toggle live pane preview panel: `p` (off by default)
 - Delete selected session/window/pane: `x`, then `x` to confirm (any other key cancels)
 - Refresh pane list: `r`
 - Search sessions/windows/panes: `/` (type to filter, `Esc` to exit search)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Each archive should contain the `jkl` binary at the top level.
 - Navigate rows: `↑`/`↓` or `j`/`k`
 - Expand/collapse selected session details (windows + panes): `l`/`h`
 - Toggle all session details (expand-all / collapse-all): `L`
-- Toggle live pane preview panel: `p` (off by default)
+- Toggle live pane preview: `p` (off by default; tmux popup launcher opens external side preview)
 - Delete selected session/window/pane: `x`, then `x` to confirm (any other key cancels)
 - Refresh pane list: `r`
 - Search sessions/windows/panes: `/` (type to filter, `Esc` to exit search)
@@ -183,7 +183,7 @@ $ tmux run-shell "~/.tmux/plugins/tpm/bin/install_plugins"
 
 Default prefix bindings (only set when the key is currently unbound):
 
-- `f`: open the agent view popup (`jkl tui`)
+- `f`: open the agent view popup (`jkl tui`); press `p` to toggle tmux side preview
 - `W`: prompt for context and run `jkl upsert '#S' --session-id '#{session_id}' --context <input>`
 - `e`: open `~/.config/jkl/session_context.json` in `nvim`
 - `S`: open pane status selector popup

--- a/jkl.tmux
+++ b/jkl.tmux
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 get_tmux_option() {
   local option="$1"
   local default="$2"
@@ -65,7 +67,7 @@ bind_prefix_key() {
   tmux bind-key "$key" "$@"
 }
 
-bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" display-popup -E -w 80% -h 70% "jkl tui"
+bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" run-shell "$CURRENT_DIR/scripts/live_popup.sh '#{pane_id}'"
 bind_prefix_key "@jkl_key_context" "W" command-prompt -p "Context for #S:" "run-shell \"jkl upsert '#S' --session-id '#{session_id}' --context '%%'\""
 bind_prefix_key "@jkl_key_edit" "e" display-popup -E -w 40% -h 40% "nvim ~/.config/jkl/session_context.json"
 bind_prefix_key "@jkl_key_pane_state" "S" run-shell 'tmux display-popup -E -w 30% -h 20% "jkl tui --pane-state --session-name \"#{session_name}\" --pane-id \"#{pane_id}\""'

--- a/jkl.tmux
+++ b/jkl.tmux
@@ -65,7 +65,7 @@ bind_prefix_key() {
   tmux bind-key "$key" "$@"
 }
 
-bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" display-popup -E -w 40% -h 40% "jkl tui"
+bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" display-popup -E -w 80% -h 70% "jkl tui"
 bind_prefix_key "@jkl_key_context" "W" command-prompt -p "Context for #S:" "run-shell \"jkl upsert '#S' --session-id '#{session_id}' --context '%%'\""
 bind_prefix_key "@jkl_key_edit" "e" display-popup -E -w 40% -h 40% "nvim ~/.config/jkl/session_context.json"
 bind_prefix_key "@jkl_key_pane_state" "S" run-shell 'tmux display-popup -E -w 30% -h 20% "jkl tui --pane-state --session-name \"#{session_name}\" --pane-id \"#{pane_id}\""'

--- a/scripts/live_popup.sh
+++ b/scripts/live_popup.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TOGGLE_EXIT_CODE=42
+SOURCE_PANE="${1:-}"
+TARGET_FILE="$(mktemp "${TMPDIR:-/tmp}/jkl-preview-target.XXXXXX")"
+PREVIEW_PANE_ID=""
+PREVIEW_ENABLED=0
+
+get_tmux_option() {
+  local option="$1"
+  local default="$2"
+  local value
+  value="$(tmux show-option -gqv "$option")"
+  if [ -n "$value" ]; then
+    echo "$value"
+  else
+    echo "$default"
+  fi
+}
+
+cleanup() {
+  if [ -n "$PREVIEW_PANE_ID" ]; then
+    tmux kill-pane -t "$PREVIEW_PANE_ID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$TARGET_FILE"
+}
+trap cleanup EXIT
+
+ensure_preview_pane() {
+  local preview_width
+  preview_width="$(get_tmux_option "@jkl_live_preview_width" "40%")"
+  local split_target=()
+  if [ -n "$SOURCE_PANE" ]; then
+    split_target=(-t "$SOURCE_PANE")
+  fi
+
+  PREVIEW_PANE_ID="$(
+    tmux split-window "${split_target[@]}" -h -l "$preview_width" -P -F "#{pane_id}" \
+      "jkl preview --target-file \"$TARGET_FILE\" --lines 120"
+  )"
+
+  if [ -n "$SOURCE_PANE" ]; then
+    tmux select-pane -t "$SOURCE_PANE" >/dev/null 2>&1 || true
+  fi
+}
+
+show_list_popup_normal() {
+  local popup_width popup_height
+  popup_width="$(get_tmux_option "@jkl_popup_width" "80%")"
+  popup_height="$(get_tmux_option "@jkl_popup_height" "70%")"
+  tmux display-popup -E -w "$popup_width" -h "$popup_height" \
+    "jkl tui --external-preview --preview-target-file \"$TARGET_FILE\""
+}
+
+show_list_popup_with_external_preview() {
+  local popup_width popup_height
+  popup_width="$(get_tmux_option "@jkl_live_popup_width" "52%")"
+  popup_height="$(get_tmux_option "@jkl_popup_height" "70%")"
+  tmux display-popup -E -w "$popup_width" -h "$popup_height" -x 0 \
+    "jkl tui --external-preview --preview-target-file \"$TARGET_FILE\""
+}
+
+while true; do
+  if [ "$PREVIEW_ENABLED" -eq 1 ]; then
+    if show_list_popup_with_external_preview; then
+      EXIT_CODE=0
+    else
+      EXIT_CODE=$?
+    fi
+  else
+    if show_list_popup_normal; then
+      EXIT_CODE=0
+    else
+      EXIT_CODE=$?
+    fi
+  fi
+
+  if [ "$EXIT_CODE" -eq "$TOGGLE_EXIT_CODE" ]; then
+    if [ "$PREVIEW_ENABLED" -eq 0 ]; then
+      PREVIEW_ENABLED=1
+      ensure_preview_pane
+    else
+      PREVIEW_ENABLED=0
+      if [ -n "$PREVIEW_PANE_ID" ]; then
+        tmux kill-pane -t "$PREVIEW_PANE_ID" >/dev/null 2>&1 || true
+        PREVIEW_PANE_ID=""
+      fi
+    fi
+    continue
+  fi
+
+  break
+done

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 
 use crate::context::{AgentStatus, ContextError};
 use crate::init::{InitPromptOption, InitScope, InitTool};
-use crate::tui::TuiError;
+use crate::tui::{TuiError, TuiExit};
+
+const TOGGLE_PREVIEW_EXIT_CODE: i32 = 42;
 
 const UPSERT_LONG_ABOUT: &str = "Upsert session or pane metadata used by jkl.
 
@@ -57,6 +59,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Tui(TuiArgs),
+    Preview(PreviewArgs),
     #[command(long_about = UPSERT_LONG_ABOUT, after_help = UPSERT_AFTER_HELP)]
     Upsert(UpsertArgs),
     Rename(RenameArgs),
@@ -78,6 +81,22 @@ struct TuiArgs {
     /// The ID of the pane to open the status selector popup for
     #[arg(long)]
     pane_id: Option<String>,
+    /// Path to a pane target file written by the list view for external previews.
+    #[arg(long, hide = true)]
+    preview_target_file: Option<PathBuf>,
+    /// Enable tmux-managed external preview orchestration.
+    #[arg(long, hide = true)]
+    external_preview: bool,
+}
+
+#[derive(Args)]
+struct PreviewArgs {
+    /// File path written by the list view containing the current pane id.
+    #[arg(long)]
+    target_file: PathBuf,
+    /// Number of lines captured from tmux for each refresh.
+    #[arg(long, default_value_t = 120)]
+    lines: usize,
 }
 
 #[derive(Args)]
@@ -194,6 +213,10 @@ pub fn run() -> Result<()> {
             info!("command=tui");
             handle_tui(args)?
         }
+        Commands::Preview(args) => {
+            info!("command=preview");
+            handle_preview(args)?
+        }
         Commands::Upsert(args) => {
             info!("command=upsert");
             handle_upsert(args)?
@@ -236,7 +259,16 @@ fn handle_tui(args: TuiArgs) -> Result<(), TuiError> {
         );
     }
     info!("tui requested");
-    crate::tui::run()
+    match crate::tui::run(args.preview_target_file, args.external_preview)? {
+        TuiExit::Quit => Ok(()),
+        TuiExit::ToggleExternalPreview => {
+            std::process::exit(TOGGLE_PREVIEW_EXIT_CODE);
+        }
+    }
+}
+
+fn handle_preview(args: PreviewArgs) -> Result<(), crate::preview::PreviewError> {
+    crate::preview::run_follow(&args.target_file, args.lines)
 }
 
 fn handle_upsert(args: UpsertArgs) -> Result<(), ContextError> {
@@ -726,6 +758,30 @@ esac
                 assert_eq!(cmd.option, Some(InitPromptOption::AgentsMd));
             }
             _ => panic!("expected init prompts command"),
+        }
+    }
+
+    #[test]
+    fn parse_preview_command_with_target_file_and_lines() {
+        let cli = Cli::try_parse_from([
+            "jkl",
+            "preview",
+            "--target-file",
+            "/tmp/jkl-preview-target",
+            "--lines",
+            "80",
+        ])
+        .expect("parse preview command");
+
+        match cli.command {
+            Commands::Preview(args) => {
+                assert_eq!(
+                    args.target_file,
+                    std::path::PathBuf::from("/tmp/jkl-preview-target")
+                );
+                assert_eq!(args.lines, 80);
+            }
+            _ => panic!("expected preview command"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod context;
 mod init;
+mod preview;
 #[cfg(test)]
 mod test_utils;
 mod tmux;

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -68,27 +68,35 @@ fn render_pane_frame(pane_id: &str, lines: usize) -> String {
 mod tests {
     use super::*;
     use std::fs;
-    use tempfile::TempDir;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_target_path(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("jkl-preview-tests-{prefix}-{nanos}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir.join("target.txt")
+    }
 
     #[test]
     fn read_target_returns_none_for_missing_file() {
-        let dir = TempDir::new().expect("temp dir");
-        let path = dir.path().join("target.txt");
+        let path = temp_target_path("missing");
         assert_eq!(read_target(&path), None);
     }
 
     #[test]
     fn read_target_trims_whitespace() {
-        let dir = TempDir::new().expect("temp dir");
-        let path = dir.path().join("target.txt");
+        let path = temp_target_path("trim");
         fs::write(&path, "  %9  \n").expect("write target");
         assert_eq!(read_target(&path), Some("%9".to_string()));
     }
 
     #[test]
     fn read_target_returns_none_for_empty_file() {
-        let dir = TempDir::new().expect("temp dir");
-        let path = dir.path().join("target.txt");
+        let path = temp_target_path("empty");
         fs::write(&path, "   \n").expect("write target");
         assert_eq!(read_target(&path), None);
     }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,0 +1,95 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+use thiserror::Error;
+
+const DEFAULT_FOLLOW_INTERVAL_MS: u64 = 120;
+const CLEAR_SCREEN: &str = "\x1b[2J\x1b[H";
+
+#[derive(Error, Debug)]
+pub enum PreviewError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+}
+
+pub fn run_follow(target_file: &Path, lines: usize) -> Result<(), PreviewError> {
+    let lines = lines.max(1);
+    let mut previous_frame = String::new();
+
+    loop {
+        let target = read_target(target_file);
+        let frame = match target {
+            Some(pane_id) => render_pane_frame(&pane_id, lines),
+            None => "Waiting for pane selection from jkl list view...\n".to_string(),
+        };
+
+        if frame != previous_frame {
+            print!("{CLEAR_SCREEN}{frame}");
+            io::stdout().flush()?;
+            previous_frame = frame;
+        }
+
+        thread::sleep(Duration::from_millis(DEFAULT_FOLLOW_INTERVAL_MS));
+    }
+}
+
+fn read_target(target_file: &Path) -> Option<String> {
+    let contents = match fs::read_to_string(target_file) {
+        Ok(contents) => contents,
+        Err(_) => return None,
+    };
+
+    let pane_id = contents.trim();
+    if pane_id.is_empty() {
+        None
+    } else {
+        Some(pane_id.to_string())
+    }
+}
+
+fn render_pane_frame(pane_id: &str, lines: usize) -> String {
+    let header = format!("Live pane preview: {pane_id}\n\n");
+    match crate::tmux::capture_pane(pane_id, lines) {
+        Ok(capture) => {
+            if capture.trim().is_empty() {
+                format!("{header}(pane is empty)\n")
+            } else {
+                format!("{header}{capture}")
+            }
+        }
+        Err(error) => format!("{header}Unable to capture pane.\n{error}\n"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn read_target_returns_none_for_missing_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("target.txt");
+        assert_eq!(read_target(&path), None);
+    }
+
+    #[test]
+    fn read_target_trims_whitespace() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("target.txt");
+        fs::write(&path, "  %9  \n").expect("write target");
+        assert_eq!(read_target(&path), Some("%9".to_string()));
+    }
+
+    #[test]
+    fn read_target_returns_none_for_empty_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("target.txt");
+        fs::write(&path, "   \n").expect("write target");
+        assert_eq!(read_target(&path), None);
+    }
+}

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -225,6 +225,28 @@ pub fn kill_pane(target: &str) -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn capture_pane(target: &str, lines: usize) -> Result<String, io::Error> {
+    let lines = lines.max(1);
+    let start = format!("-{lines}");
+    let output = Command::new("tmux")
+        .args(["capture-pane", "-p", "-t", target, "-S", start.as_str()])
+        .output()?;
+    if !output.status.success() {
+        let err = tmux_status_error("capture-pane", output.status, &output.stderr);
+        debug!("tmux capture-pane failed target={target} error={err}");
+        return Err(err);
+    }
+
+    let captured = String::from_utf8_lossy(&output.stdout).to_string();
+    debug!(
+        "tmux capture-pane target={} lines={} bytes={}",
+        target,
+        lines,
+        captured.len()
+    );
+    Ok(captured)
+}
+
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
@@ -275,6 +297,14 @@ case "$1" in
       echo "${TMUX_SELECT_PANE_ERR:-error}" 1>&2
       exit 1
     fi
+    exit 0
+    ;;
+  capture-pane)
+    if [ "${TMUX_CAPTURE_PANE_EXIT:-0}" -ne 0 ]; then
+      echo "${TMUX_CAPTURE_PANE_ERR:-error}" 1>&2
+      exit "${TMUX_CAPTURE_PANE_EXIT}"
+    fi
+    printf "%s" "${TMUX_CAPTURE_PANE:-}"
     exit 0
     ;;
   *)
@@ -454,6 +484,32 @@ esac
         assert_eq!(
             err.to_string(),
             "tmux select-window failed (exit code 1): no window"
+        );
+    }
+
+    #[test]
+    fn capture_pane_returns_captured_text() {
+        let mut env = EnvGuard::new("tmux-capture-pane-ok");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_CAPTURE_PANE", "line one\nline two\n");
+        env.remove_var("TMUX_CAPTURE_PANE_EXIT");
+
+        let text = capture_pane("%1", 25).expect("capture pane");
+        assert_eq!(text, "line one\nline two\n");
+    }
+
+    #[test]
+    fn capture_pane_returns_error_on_failure() {
+        let mut env = EnvGuard::new("tmux-capture-pane-error");
+        setup_fake_tmux(&mut env);
+        env.set_var("TMUX_CAPTURE_PANE_EXIT", "1");
+        env.set_var("TMUX_CAPTURE_PANE_ERR", "pane not found");
+
+        let err = capture_pane("%404", 25).expect_err("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(
+            err.to_string(),
+            "tmux capture-pane failed (exit code 1): pane not found"
         );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,10 +16,13 @@ use nucleo::{Config as NucleoConfig, Matcher as NucleoMatcher};
 const DATA_NOT_RECEIVED: &str = "-";
 // TODO: Will make this configurable in the future.
 const PANE_LABEL_MAX_WIDTH: usize = 10;
-const INFO_TEXT: &str = "(?) help | (Esc/Ctrl+C) back/quit | (/) search | (Enter) switch | (↑/↓) move | (g/G) top/bottom | (0-9/Opt-a..z) jump | (l/h) expand/collapse | (L) toggle all | (x) delete selected | (r) refresh";
+const PREVIEW_CAPTURE_LINES: usize = 120;
+const PREVIEW_DEFAULT_TEXT: &str =
+    "Preview is off. Press 'p' to toggle live pane preview for the selected row.";
+const INFO_TEXT: &str = "(?) help | (Esc/Ctrl+C) back/quit | (/) search | (Enter) switch | (↑/↓) move | (g/G) top/bottom | (0-9/Opt-a..z) jump | (l/h) expand/collapse | (L) toggle all | (p) preview | (x) delete selected | (r) refresh";
 const HELP_FEEDBACK_TEXT: &str =
     "Feedback: create an issue at https://github.com/cruzluna/jkl-2/issues";
-const HELP_BINDINGS: [(&str, &str, &str); 19] = [
+const HELP_BINDINGS: [(&str, &str, &str); 20] = [
     ("Normal", "q / Esc / Ctrl-C", "Quit list view"),
     ("Normal", "?", "Open this help"),
     ("Normal", "/", "Search sessions/windows/panes"),
@@ -30,6 +33,7 @@ const HELP_BINDINGS: [(&str, &str, &str); 19] = [
     ("Normal", "Opt-a..z", "Jump to session index 10-35"),
     ("Normal", "l / h", "Expand/collapse selected session"),
     ("Normal", "L", "Toggle all sessions expanded/collapsed"),
+    ("Normal", "p", "Toggle live pane preview"),
     ("Normal", "x", "Start delete confirmation"),
     ("Normal", "r", "Refresh pane list"),
     ("Search", "type / Backspace", "Filter sessions"),
@@ -231,6 +235,11 @@ struct SearchCandidate {
     search_text: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PreviewTarget {
+    pane_id: String,
+}
+
 impl AsRef<str> for SearchCandidate {
     fn as_ref(&self) -> &str {
         &self.search_text
@@ -309,6 +318,10 @@ struct App<S: SessionSearch> {
     search: SearchQuery,
     mode: ListViewModes,
     expanded_sessions: HashSet<String>,
+    preview_enabled: bool,
+    preview_target_pane_id: Option<String>,
+    preview_title: String,
+    preview_text: String,
     filter: S,
 }
 
@@ -341,6 +354,10 @@ impl<S: SessionSearch> App<S> {
             },
             mode: ListViewModes::NormalMode,
             expanded_sessions: HashSet::new(),
+            preview_enabled: false,
+            preview_target_pane_id: None,
+            preview_title: "Pane Preview".to_string(),
+            preview_text: PREVIEW_DEFAULT_TEXT.to_string(),
             filter,
         };
         app.rebuild_rows();
@@ -433,6 +450,7 @@ impl<S: SessionSearch> App<S> {
                         }
                         KeyCode::Char('l') => self.expand_selected(),
                         KeyCode::Char('h') => self.collapse_selected(),
+                        KeyCode::Char('p') => self.toggle_preview(),
                         KeyCode::Char('x') => self.enter_delete_mode(),
                         KeyCode::Char('r') => {
                             info!("tui refresh requested");
@@ -738,6 +756,9 @@ impl<S: SessionSearch> App<S> {
         self.filtered_sessions = self.sessions.clone();
         self.rebuild_rows();
         self.apply_search_with(previous)?;
+        if self.preview_enabled {
+            self.sync_preview_to_selection(true);
+        }
         info!(
             "tui reloaded {} sessions, {} rows",
             self.sessions.len(),
@@ -754,7 +775,16 @@ impl<S: SessionSearch> App<S> {
         ]);
         let sections = layout.split(frame.area());
         self.render_search(frame, sections[0]);
-        self.render_table(frame, sections[1]);
+        if self.preview_enabled {
+            self.sync_preview_to_selection(false);
+            let split =
+                Layout::horizontal([Constraint::Percentage(52), Constraint::Percentage(48)])
+                    .split(sections[1]);
+            self.render_table(frame, split[0]);
+            self.render_preview(frame, split[1]);
+        } else {
+            self.render_table(frame, sections[1]);
+        }
         self.render_footer(frame, sections[2]);
         if matches!(self.mode, ListViewModes::HelpMode) {
             self.render_help_overlay(frame);
@@ -836,6 +866,17 @@ impl<S: SessionSearch> App<S> {
 
         frame.render_widget(footer, sections[0]);
         frame.render_widget(mode_widget, sections[1]);
+    }
+
+    fn render_preview(&self, frame: &mut Frame, area: Rect) {
+        let preview = Paragraph::new(Text::from(self.preview_text.clone()))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(&self.preview_title),
+            )
+            .wrap(Wrap { trim: false });
+        frame.render_widget(preview, area);
     }
 
     fn render_help_overlay(&self, frame: &mut Frame) {
@@ -1028,6 +1069,75 @@ impl<S: SessionSearch> App<S> {
             RowItem::Window(_) | RowItem::Pane(_) => false,
         }) {
             self.state.select(Some(row_index));
+        }
+    }
+
+    fn toggle_preview(&mut self) {
+        self.preview_enabled = !self.preview_enabled;
+        if self.preview_enabled {
+            self.sync_preview_to_selection(true);
+        } else {
+            self.preview_target_pane_id = None;
+            self.preview_title = "Pane Preview".to_string();
+            self.preview_text = PREVIEW_DEFAULT_TEXT.to_string();
+        }
+    }
+
+    fn sync_preview_to_selection(&mut self, force: bool) {
+        if !self.preview_enabled {
+            return;
+        }
+
+        let target = self.preview_target_for_selected_row();
+        let target_id = target.as_ref().map(|target| target.pane_id.clone());
+        if !force && self.preview_target_pane_id == target_id {
+            return;
+        }
+
+        self.preview_target_pane_id = target_id.clone();
+
+        let Some(target) = target else {
+            self.preview_title = "Pane Preview".to_string();
+            self.preview_text = "No pane available for the current selection.".to_string();
+            return;
+        };
+
+        self.preview_title = format!("Pane {}", target.pane_id);
+        match crate::tmux::capture_pane(&target.pane_id, PREVIEW_CAPTURE_LINES) {
+            Ok(text) => {
+                self.preview_text = if text.trim().is_empty() {
+                    "(pane is empty)".to_string()
+                } else {
+                    text
+                };
+            }
+            Err(error) => {
+                error!(
+                    "tui preview capture failed pane_id={} error={error}",
+                    target.pane_id
+                );
+                self.preview_text =
+                    format!("Unable to capture pane {}.\n{}", target.pane_id, error);
+            }
+        }
+    }
+
+    fn preview_target_for_selected_row(&self) -> Option<PreviewTarget> {
+        match self.selected_row() {
+            Some(RowItem::Pane(row)) => Some(PreviewTarget {
+                pane_id: row.id.clone(),
+            }),
+            Some(RowItem::Window(row)) => row.panes.first().map(|pane| PreviewTarget {
+                pane_id: pane.id.clone(),
+            }),
+            Some(RowItem::Session(row)) => row
+                .windows
+                .iter()
+                .find_map(|window| window.panes.first())
+                .map(|pane| PreviewTarget {
+                    pane_id: pane.id.clone(),
+                }),
+            None => None,
         }
     }
 }
@@ -1494,6 +1604,50 @@ mod tests {
                 }],
                 session_id: "@1".to_string(),
             }],
+        }
+    }
+
+    fn session_with_sparse_windows_for_preview() -> SessionRow {
+        SessionRow {
+            id: "@1".to_string(),
+            name: "alpha".to_string(),
+            status: None,
+            context: "ctx".to_string(),
+            windows: vec![
+                WindowRow {
+                    id: "@10".to_string(),
+                    name: "empty".to_string(),
+                    status: None,
+                    context: "wctx".to_string(),
+                    panes: Vec::new(),
+                    session_id: "@1".to_string(),
+                },
+                WindowRow {
+                    id: "@20".to_string(),
+                    name: "editor".to_string(),
+                    status: None,
+                    context: "wctx".to_string(),
+                    panes: vec![
+                        PaneRow {
+                            id: "%9".to_string(),
+                            window_id: "@20".to_string(),
+                            alias: None,
+                            status: None,
+                            context: "pctx".to_string(),
+                            session_id: "@1".to_string(),
+                        },
+                        PaneRow {
+                            id: "%10".to_string(),
+                            window_id: "@20".to_string(),
+                            alias: None,
+                            status: None,
+                            context: "pctx".to_string(),
+                            session_id: "@1".to_string(),
+                        },
+                    ],
+                    session_id: "@1".to_string(),
+                },
+            ],
         }
     }
 
@@ -1980,6 +2134,54 @@ esac
             RowItem::Session(row) => assert_eq!(row.id, "@2"),
             RowItem::Window(_) | RowItem::Pane(_) => panic!("expected session row"),
         }
+    }
+
+    #[test]
+    fn preview_is_disabled_by_default() {
+        let sessions = vec![session_row("@1", "alpha")];
+        let app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        assert!(!app.preview_enabled);
+        assert_eq!(app.preview_text, PREVIEW_DEFAULT_TEXT);
+    }
+
+    #[test]
+    fn preview_target_for_pane_row_uses_selected_pane() {
+        let sessions = vec![session_with_window_and_pane()];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+        app.state.select(Some(2));
+
+        let target = app
+            .preview_target_for_selected_row()
+            .expect("preview target");
+        assert_eq!(target.pane_id, "%1");
+    }
+
+    #[test]
+    fn preview_target_for_window_row_uses_first_pane() {
+        let sessions = vec![session_with_sparse_windows_for_preview()];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+        app.state.select(Some(2));
+
+        let target = app
+            .preview_target_for_selected_row()
+            .expect("preview target");
+        assert_eq!(target.pane_id, "%9");
+    }
+
+    #[test]
+    fn preview_target_for_session_row_uses_first_available_pane() {
+        let sessions = vec![session_with_sparse_windows_for_preview()];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        app.state.select(Some(0));
+
+        let target = app
+            .preview_target_for_selected_row()
+            .expect("preview target");
+        assert_eq!(target.pane_id, "%9");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2260,8 +2260,13 @@ esac
 
     #[test]
     fn sync_external_preview_target_writes_selected_pane_to_file() {
-        let dir = tempfile::TempDir::new().expect("temp dir");
-        let target_file = dir.path().join("pane_target.txt");
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("jkl-tui-preview-target-{nanos}"));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let target_file = dir.join("pane_target.txt");
         let sessions = vec![session_with_sparse_windows_for_preview()];
         let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
         app.external_preview = true;
@@ -2272,6 +2277,7 @@ esac
 
         let contents = std::fs::read_to_string(&target_file).expect("read target file");
         assert_eq!(contents, "%9\n");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,7 +5,9 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap};
 use ratatui::{DefaultTerminal, Frame};
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::io;
+use std::path::PathBuf;
 use thiserror::Error;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -57,6 +59,12 @@ pub enum TuiError {
     TerminalIo(#[from] io::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiExit {
+    Quit,
+    ToggleExternalPreview,
+}
+
 fn backend_failure(source: impl std::fmt::Display) -> TuiError {
     let message = source.to_string();
     error!("tui backend failure: {message}");
@@ -74,7 +82,10 @@ fn search_failure(message: String) -> TuiError {
     TuiError::SearchFailure(message)
 }
 
-pub fn run() -> Result<(), TuiError> {
+pub fn run(
+    preview_target_file: Option<PathBuf>,
+    external_preview: bool,
+) -> Result<TuiExit, TuiError> {
     info!("tui starting");
     let sessions = crate::tmux::list_sessions().map_err(backend_failure)?;
     info!(
@@ -93,6 +104,8 @@ pub fn run() -> Result<(), TuiError> {
     info!("tui built {} session rows", items.len());
 
     let mut app = App::new(items)?;
+    app.preview_target_file = preview_target_file;
+    app.external_preview = external_preview;
     let mut terminal = ratatui::init();
     let result = app.run(&mut terminal);
     ratatui::restore();
@@ -318,6 +331,9 @@ struct App<S: SessionSearch> {
     search: SearchQuery,
     mode: ListViewModes,
     expanded_sessions: HashSet<String>,
+    external_preview: bool,
+    preview_target_file: Option<PathBuf>,
+    external_preview_target_pane_id: Option<String>,
     preview_enabled: bool,
     preview_target_pane_id: Option<String>,
     preview_title: String,
@@ -354,6 +370,9 @@ impl<S: SessionSearch> App<S> {
             },
             mode: ListViewModes::NormalMode,
             expanded_sessions: HashSet::new(),
+            external_preview: false,
+            preview_target_file: None,
+            external_preview_target_pane_id: None,
             preview_enabled: false,
             preview_target_pane_id: None,
             preview_title: "Pane Preview".to_string(),
@@ -365,7 +384,10 @@ impl<S: SessionSearch> App<S> {
         Ok(app)
     }
     /// Runs the main event loop for the list view
-    fn run(&mut self, terminal: &mut DefaultTerminal) -> Result<(), TuiError> {
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> Result<TuiExit, TuiError> {
+        if self.external_preview {
+            self.sync_external_preview_target(true)?;
+        }
         loop {
             terminal.draw(|frame| self.draw(frame))?;
 
@@ -391,7 +413,7 @@ impl<S: SessionSearch> App<S> {
                         }
                         KeyCode::Enter => {
                             self.switch_session()?;
-                            return Ok(());
+                            return Ok(TuiExit::Quit);
                         }
                         KeyCode::Backspace => {
                             self.search.query.pop();
@@ -418,12 +440,15 @@ impl<S: SessionSearch> App<S> {
                         && let Some(index) = meta_jump_index(c)
                     {
                         self.jump_to_session_index(index);
+                        if self.external_preview {
+                            self.sync_external_preview_target(false)?;
+                        }
                         continue;
                     }
                     match key.code {
-                        KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                        KeyCode::Char('q') | KeyCode::Esc => return Ok(TuiExit::Quit),
                         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            return Ok(());
+                            return Ok(TuiExit::Quit);
                         }
                         KeyCode::Char('/') => {
                             self.mode = ListViewModes::SearchMode;
@@ -434,7 +459,7 @@ impl<S: SessionSearch> App<S> {
                         }
                         KeyCode::Enter => {
                             self.switch_session()?;
-                            return Ok(());
+                            return Ok(TuiExit::Quit);
                         }
                         KeyCode::Char('j') | KeyCode::Down => self.next_row(),
                         KeyCode::Char('k') | KeyCode::Up => self.previous_row(),
@@ -450,7 +475,11 @@ impl<S: SessionSearch> App<S> {
                         }
                         KeyCode::Char('l') => self.expand_selected(),
                         KeyCode::Char('h') => self.collapse_selected(),
-                        KeyCode::Char('p') => self.toggle_preview(),
+                        KeyCode::Char('p') => {
+                            if let Some(exit) = self.handle_preview_key() {
+                                return Ok(exit);
+                            }
+                        }
                         KeyCode::Char('x') => self.enter_delete_mode(),
                         KeyCode::Char('r') => {
                             info!("tui refresh requested");
@@ -462,6 +491,10 @@ impl<S: SessionSearch> App<S> {
                         }
                         _ => {}
                     }
+                }
+
+                if self.external_preview {
+                    self.sync_external_preview_target(false)?;
                 }
             }
         }
@@ -756,6 +789,9 @@ impl<S: SessionSearch> App<S> {
         self.filtered_sessions = self.sessions.clone();
         self.rebuild_rows();
         self.apply_search_with(previous)?;
+        if self.external_preview {
+            self.sync_external_preview_target(true)?;
+        }
         if self.preview_enabled {
             self.sync_preview_to_selection(true);
         }
@@ -775,7 +811,7 @@ impl<S: SessionSearch> App<S> {
         ]);
         let sections = layout.split(frame.area());
         self.render_search(frame, sections[0]);
-        if self.preview_enabled {
+        if self.preview_enabled && !self.external_preview {
             self.sync_preview_to_selection(false);
             let split =
                 Layout::horizontal([Constraint::Percentage(52), Constraint::Percentage(48)])
@@ -1072,6 +1108,14 @@ impl<S: SessionSearch> App<S> {
         }
     }
 
+    fn handle_preview_key(&mut self) -> Option<TuiExit> {
+        if self.external_preview {
+            return Some(TuiExit::ToggleExternalPreview);
+        }
+        self.toggle_preview();
+        None
+    }
+
     fn toggle_preview(&mut self) {
         self.preview_enabled = !self.preview_enabled;
         if self.preview_enabled {
@@ -1081,6 +1125,27 @@ impl<S: SessionSearch> App<S> {
             self.preview_title = "Pane Preview".to_string();
             self.preview_text = PREVIEW_DEFAULT_TEXT.to_string();
         }
+    }
+
+    fn sync_external_preview_target(&mut self, force: bool) -> Result<(), TuiError> {
+        if !self.external_preview {
+            return Ok(());
+        }
+
+        let target = self.preview_target_for_selected_row();
+        let target_id = target.map(|target| target.pane_id);
+        if !force && self.external_preview_target_pane_id == target_id {
+            return Ok(());
+        }
+        self.external_preview_target_pane_id = target_id.clone();
+
+        let Some(target_file) = &self.preview_target_file else {
+            return Ok(());
+        };
+        let mut value = target_id.unwrap_or_default();
+        value.push('\n');
+        fs::write(target_file, value)?;
+        Ok(())
     }
 
     fn sync_preview_to_selection(&mut self, force: bool) {
@@ -2182,6 +2247,31 @@ esac
             .preview_target_for_selected_row()
             .expect("preview target");
         assert_eq!(target.pane_id, "%9");
+    }
+
+    #[test]
+    fn handle_preview_key_returns_toggle_exit_for_external_preview() {
+        let sessions = vec![session_with_window_and_pane()];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        app.external_preview = true;
+        let exit = app.handle_preview_key();
+        assert_eq!(exit, Some(TuiExit::ToggleExternalPreview));
+    }
+
+    #[test]
+    fn sync_external_preview_target_writes_selected_pane_to_file() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let target_file = dir.path().join("pane_target.txt");
+        let sessions = vec![session_with_sparse_windows_for_preview()];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        app.external_preview = true;
+        app.preview_target_file = Some(target_file.clone());
+
+        app.sync_external_preview_target(true)
+            .expect("sync preview target");
+
+        let contents = std::fs::read_to_string(&target_file).expect("read target file");
+        assert_eq!(contents, "%9\n");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -873,7 +873,7 @@ impl<S: SessionSearch> App<S> {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .title(&self.preview_title),
+                    .title(self.preview_title.as_str()),
             )
             .wrap(Wrap { trim: false });
         frame.render_widget(preview, area);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a toggleable live pane preview to the TUI, similar to `tmux choose-tree` mode, to enhance navigation and context.

The preview is default-off, toggled by `p`, updates on selection change, and shows the first pane's content when a session or window is selected. The tmux popup dimensions have also been increased for better readability.

<div><a href="https://cursor.com/agents/bc-d29afd93-293d-4b4b-9901-cf3212b76790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d29afd93-293d-4b4b-9901-cf3212b76790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->