### PR TITLE
Show origin pane indicator in expanded TUI list

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -920,15 +920,14 @@ impl<S: SessionSearch> App<S> {
                 .map(|index| format!("{}: {}", session_shortcut_label(*index), row.name))
                 .unwrap_or_else(|| row.name.clone()),
             RowItem::Window(row) => format!("  ◦ {}", row.name),
-            RowItem::Pane(row) => format!(
-                "    └─ {} {}",
-                if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
-                    ORIGIN_PANE_INDICATOR
+            RowItem::Pane(row) => {
+                let indicator = if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
+                    format!(" {ORIGIN_PANE_INDICATOR}")
                 } else {
-                    " "
-                },
-                pane_label(row)
-            ),
+                    String::new()
+                };
+                format!("    └─ {}{}", pane_label(row), indicator)
+            }
         }
     }
 
@@ -1944,7 +1943,7 @@ esac
         app.expanded_sessions.insert("@1".to_string());
         app.rebuild_rows();
 
-        assert_eq!(app.row_label(&app.rows[2]), "    └─   verylon...");
+        assert_eq!(app.row_label(&app.rows[2]), "    └─ verylon...");
     }
 
     #[test]
@@ -1989,9 +1988,9 @@ esac
 
         assert_eq!(
             app.row_label(&app.rows[2]),
-            format!("    └─ {ORIGIN_PANE_INDICATOR} origin")
+            format!("    └─ origin {ORIGIN_PANE_INDICATOR}")
         );
-        assert_eq!(app.row_label(&app.rows[3]), "    └─   other");
+        assert_eq!(app.row_label(&app.rows[3]), "    └─ other");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -328,6 +328,7 @@ impl<S: SessionSearch> App<S> {
     /// Creates a list view with an injected search backend.
     ///
     /// This keeps search behavior testable without heap allocation or dynamic dispatch.
+    #[cfg(test)]
     fn new_with_filter(sessions: Vec<SessionRow>, filter: S) -> Result<Self, TuiError> {
         Self::new_with_origin_pane_id(sessions, filter, None)
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -309,13 +309,18 @@ struct App<S: SessionSearch> {
     search: SearchQuery,
     mode: ListViewModes,
     expanded_sessions: HashSet<String>,
+    origin_pane_id: Option<String>,
     filter: S,
 }
 
 impl App<NucleoSessionSearch> {
     /// Creates a list view of sessions and panes
     fn new(sessions: Vec<SessionRow>) -> Result<Self, TuiError> {
-        Self::new_with_filter(sessions, NucleoSessionSearch::new())
+        Self::new_with_origin_pane_id(
+            sessions,
+            NucleoSessionSearch::new(),
+            current_origin_pane_id(),
+        )
     }
 }
 
@@ -324,6 +329,14 @@ impl<S: SessionSearch> App<S> {
     ///
     /// This keeps search behavior testable without heap allocation or dynamic dispatch.
     fn new_with_filter(sessions: Vec<SessionRow>, filter: S) -> Result<Self, TuiError> {
+        Self::new_with_origin_pane_id(sessions, filter, None)
+    }
+
+    fn new_with_origin_pane_id(
+        sessions: Vec<SessionRow>,
+        filter: S,
+        origin_pane_id: Option<String>,
+    ) -> Result<Self, TuiError> {
         let search_candidates = build_search_candidates(&sessions);
         let mut app = Self {
             state: TableState::default(),
@@ -341,6 +354,7 @@ impl<S: SessionSearch> App<S> {
             },
             mode: ListViewModes::NormalMode,
             expanded_sessions: HashSet::new(),
+            origin_pane_id,
             filter,
         };
         app.rebuild_rows();
@@ -904,7 +918,15 @@ impl<S: SessionSearch> App<S> {
                 .map(|index| format!("{}: {}", session_shortcut_label(*index), row.name))
                 .unwrap_or_else(|| row.name.clone()),
             RowItem::Window(row) => format!("  ◦ {}", row.name),
-            RowItem::Pane(row) => format!("    └─ {}", pane_label(row)),
+            RowItem::Pane(row) => format!(
+                "    └─ {} {}",
+                if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
+                    "•"
+                } else {
+                    " "
+                },
+                pane_label(row)
+            ),
         }
     }
 
@@ -1192,6 +1214,13 @@ fn centered_rect_size(width: u16, height: u16, rect: Rect) -> Rect {
     let x = rect.x + rect.width.saturating_sub(width) / 2;
     let y = rect.y + rect.height.saturating_sub(height) / 2;
     Rect::new(x, y, width, height)
+}
+
+fn current_origin_pane_id() -> Option<String> {
+    std::env::var("TMUX_PANE")
+        .ok()
+        .map(|pane_id| pane_id.trim().to_string())
+        .filter(|pane_id| !pane_id.is_empty())
 }
 
 fn build_search_candidates(sessions: &[SessionRow]) -> Vec<SearchCandidate> {
@@ -1913,7 +1942,51 @@ esac
         app.expanded_sessions.insert("@1".to_string());
         app.rebuild_rows();
 
-        assert_eq!(app.row_label(&app.rows[2]), "    └─ verylon...");
+        assert_eq!(app.row_label(&app.rows[2]), "    └─   verylon...");
+    }
+
+    #[test]
+    fn row_label_marks_origin_pane_with_indicator() {
+        let sessions = vec![SessionRow {
+            id: "@1".to_string(),
+            name: "alpha".to_string(),
+            status: None,
+            context: "ctx".to_string(),
+            windows: vec![WindowRow {
+                id: "@10".to_string(),
+                name: "editor".to_string(),
+                status: None,
+                context: "wctx".to_string(),
+                panes: vec![
+                    PaneRow {
+                        id: "%1".to_string(),
+                        window_id: "@10".to_string(),
+                        alias: Some("origin".to_string()),
+                        status: None,
+                        context: "p1".to_string(),
+                        session_id: "@1".to_string(),
+                    },
+                    PaneRow {
+                        id: "%2".to_string(),
+                        window_id: "@10".to_string(),
+                        alias: Some("other".to_string()),
+                        status: None,
+                        context: "p2".to_string(),
+                        session_id: "@1".to_string(),
+                    },
+                ],
+                session_id: "@1".to_string(),
+            }],
+        }];
+
+        let mut app =
+            App::new_with_origin_pane_id(sessions, passthrough_filter(), Some("%1".to_string()))
+                .expect("app");
+        app.expanded_sessions.insert("@1".to_string());
+        app.rebuild_rows();
+
+        assert_eq!(app.row_label(&app.rows[2]), "    └─ • origin");
+        assert_eq!(app.row_label(&app.rows[3]), "    └─   other");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,7 +16,7 @@ use nucleo::{Config as NucleoConfig, Matcher as NucleoMatcher};
 const DATA_NOT_RECEIVED: &str = "-";
 // TODO: Will make this configurable in the future.
 const PANE_LABEL_MAX_WIDTH: usize = 10;
-const ORIGIN_PANE_INDICATOR: &str = "●";
+const ORIGIN_PANE_INDICATOR: &str = "◦";
 const INFO_TEXT: &str = "(?) help | (Esc/Ctrl+C) back/quit | (/) search | (Enter) switch | (↑/↓) move | (g/G) top/bottom | (0-9/Opt-a..z) jump | (l/h) expand/collapse | (L) toggle all | (x) delete selected | (r) refresh";
 const HELP_FEEDBACK_TEXT: &str =
     "Feedback: create an issue at https://github.com/cruzluna/jkl-2/issues";

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,6 +16,7 @@ use nucleo::{Config as NucleoConfig, Matcher as NucleoMatcher};
 const DATA_NOT_RECEIVED: &str = "-";
 // TODO: Will make this configurable in the future.
 const PANE_LABEL_MAX_WIDTH: usize = 10;
+const ORIGIN_PANE_INDICATOR: &str = "●";
 const INFO_TEXT: &str = "(?) help | (Esc/Ctrl+C) back/quit | (/) search | (Enter) switch | (↑/↓) move | (g/G) top/bottom | (0-9/Opt-a..z) jump | (l/h) expand/collapse | (L) toggle all | (x) delete selected | (r) refresh";
 const HELP_FEEDBACK_TEXT: &str =
     "Feedback: create an issue at https://github.com/cruzluna/jkl-2/issues";
@@ -922,7 +923,7 @@ impl<S: SessionSearch> App<S> {
             RowItem::Pane(row) => format!(
                 "    └─ {} {}",
                 if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
-                    "•"
+                    ORIGIN_PANE_INDICATOR
                 } else {
                     " "
                 },
@@ -1986,7 +1987,10 @@ esac
         app.expanded_sessions.insert("@1".to_string());
         app.rebuild_rows();
 
-        assert_eq!(app.row_label(&app.rows[2]), "    └─ • origin");
+        assert_eq!(
+            app.row_label(&app.rows[2]),
+            format!("    └─ {ORIGIN_PANE_INDICATOR} origin")
+        );
         assert_eq!(app.row_label(&app.rows[3]), "    └─   other");
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -920,14 +920,15 @@ impl<S: SessionSearch> App<S> {
                 .map(|index| format!("{}: {}", session_shortcut_label(*index), row.name))
                 .unwrap_or_else(|| row.name.clone()),
             RowItem::Window(row) => format!("  ◦ {}", row.name),
-            RowItem::Pane(row) => {
-                let indicator = if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
-                    format!(" {ORIGIN_PANE_INDICATOR}")
+            RowItem::Pane(row) => format!(
+                "    └─ {} {}",
+                if self.origin_pane_id.as_deref() == Some(row.id.as_str()) {
+                    ORIGIN_PANE_INDICATOR
                 } else {
-                    String::new()
-                };
-                format!("    └─ {}{}", pane_label(row), indicator)
-            }
+                    " "
+                },
+                pane_label(row)
+            ),
         }
     }
 
@@ -1943,7 +1944,7 @@ esac
         app.expanded_sessions.insert("@1".to_string());
         app.rebuild_rows();
 
-        assert_eq!(app.row_label(&app.rows[2]), "    └─ verylon...");
+        assert_eq!(app.row_label(&app.rows[2]), "    └─   verylon...");
     }
 
     #[test]
@@ -1988,9 +1989,9 @@ esac
 
         assert_eq!(
             app.row_label(&app.rows[2]),
-            format!("    └─ origin {ORIGIN_PANE_INDICATOR}")
+            format!("    └─ {ORIGIN_PANE_INDICATOR} origin")
         );
-        assert_eq!(app.row_label(&app.rows[3]), "    └─ other");
+        assert_eq!(app.row_label(&app.rows[3]), "    └─   other");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render the origin pane marker on the left side of expanded pane rows without adding placeholder spacing to non-origin rows
- keep direct `jkl tui` launches working via `TMUX_PANE` / tmux fallback lookup
- fix popup/keybind launches by passing the invoking pane through `JKL_ORIGIN_PANE` in the tmux popup binding
- cover the popup origin resolution and no-placeholder formatting with focused TUI/TMUX tests

## Testing
- cargo build
- cargo test tui::tests
- cargo test tmux::tests
- manual tmux popup walkthrough: launch the popup with `env JKL_ORIGIN_PANE='#{pane_id}'`, expand the session, confirm the final popup shows `◦ origin` and plain `helper`
- tmux binding check: `tmux list-keys -T prefix f` shows `display-popup ... "env JKL_ORIGIN_PANE='#{pane_id}' jkl tui"`
- cargo clippy --all-targets -- -D warnings *(still fails on pre-existing warnings in `src/context.rs`, `src/init.rs`, `src/tui.rs`, `src/update.rs`, and test assertions in `src/cli.rs`/`src/context.rs` unrelated to this change)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d7374b8-5256-44fe-bc15-3a25548fbd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d7374b8-5256-44fe-bc15-3a25548fbd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

