### PR TITLE
feat: add TUI context display config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror 2.0.18",
+ "toml",
  "unicode-width",
 ]
 
@@ -2103,6 +2104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2544,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower-service"
@@ -3161,6 +3210,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ log = "0.4.28"
 self_update = { version = "0.39.0", default-features = false, features = ["archive-tar", "compression-flate2", "rustls"] }
 inquire = "0.9.1"
 nucleo = "0.5.0"
+toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ Each archive should contain the `jkl` binary at the top level.
 
 Multi-word session names or context can be passed without quotes; use `--` to terminate positional values if needed.
 
+## Configuration
+
+`jkl` reads optional configuration from `~/.config/jkl/jkl.toml`. If the file does not exist, it is created with defaults.
+On narrow terminals, `jkl tui` hides context automatically to keep session names and statuses readable.
+
+```toml
+[features]
+# Set false to hide the Context column in `jkl tui`.
+tui_context = true
+```
+
 ## Tmux Plugin (TPM)
 
 Add the plugin and reload TPM:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -590,7 +590,7 @@ mod tests {
         handle_rename(args).expect("handle rename");
 
         let contexts = load_contexts().expect("load contexts");
-        assert!(contexts.get(&session_key("Old")).is_none());
+        assert!(!contexts.contains_key(&session_key("Old")));
         let entry = contexts
             .get(&session_key("New Name"))
             .expect("renamed entry");
@@ -656,8 +656,8 @@ esac
         handle_sync().expect("sync");
 
         let contexts = load_contexts().expect("load contexts");
-        assert!(contexts.get(&session_key("old-name")).is_none());
-        assert!(contexts.get(&session_key("gone")).is_none());
+        assert!(!contexts.contains_key(&session_key("old-name")));
+        assert!(!contexts.contains_key(&session_key("gone")));
         let renamed = contexts
             .get(&session_key("new-name"))
             .expect("renamed session");

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,18 +11,10 @@ const DEFAULT_CONFIG: &str = r#"# jkl configuration
 tui_context = true
 "#;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct JklConfig {
     pub features: FeatureConfig,
-}
-
-impl Default for JklConfig {
-    fn default() -> Self {
-        Self {
-            features: FeatureConfig::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,133 @@
+use log::{debug, info};
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+use thiserror::Error;
+
+const DEFAULT_CONFIG: &str = r#"# jkl configuration
+
+[features]
+# Show the Context column in `jkl tui` when the terminal is wide enough.
+tui_context = true
+"#;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct JklConfig {
+    pub features: FeatureConfig,
+}
+
+impl Default for JklConfig {
+    fn default() -> Self {
+        Self {
+            features: FeatureConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct FeatureConfig {
+    pub tui_context: bool,
+}
+
+impl Default for FeatureConfig {
+    fn default() -> Self {
+        Self { tui_context: true }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML error: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("Environment variable not found: {0}")]
+    EnvVar(#[from] std::env::VarError),
+}
+
+pub fn load_config() -> Result<JklConfig, ConfigError> {
+    let path = config_path()?;
+    debug!("loading config path={}", path.display());
+    let contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            info!(
+                "config file missing, creating default at {}",
+                path.display()
+            );
+            fs::write(&path, DEFAULT_CONFIG)?;
+            return Ok(JklConfig::default());
+        }
+        Err(error) => return Err(ConfigError::Io(error)),
+    };
+
+    let config = toml::from_str(&contents)?;
+    debug!("loaded config: {:?}", config);
+    Ok(config)
+}
+
+fn config_path() -> Result<PathBuf, ConfigError> {
+    let home = std::env::var("HOME")?;
+    let path = PathBuf::from(home)
+        .join(".config")
+        .join("jkl")
+        .join("jkl.toml");
+    debug!("resolved config path={}", path.display());
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::EnvGuard;
+
+    #[test]
+    fn load_config_creates_missing_file_with_defaults() {
+        let mut env = EnvGuard::new("config-load");
+        env.set_temp_home();
+        let path = config_path().expect("config path");
+        assert!(!path.exists());
+
+        let config = load_config().expect("load config");
+
+        assert!(config.features.tui_context);
+        assert!(path.exists());
+        let contents = fs::read_to_string(path).expect("read config");
+        assert!(contents.contains("tui_context = true"));
+    }
+
+    #[test]
+    fn load_config_reads_tui_context_feature_flag() {
+        let mut env = EnvGuard::new("config-tui-context");
+        let home = env.set_temp_home();
+        let config_dir = home.join(".config").join("jkl");
+        fs::create_dir_all(&config_dir).expect("create config dir");
+        fs::write(
+            config_dir.join("jkl.toml"),
+            "[features]\ntui_context = false\n",
+        )
+        .expect("write config");
+
+        let config = load_config().expect("load config");
+
+        assert!(!config.features.tui_context);
+    }
+
+    #[test]
+    fn load_config_defaults_missing_feature_values() {
+        let mut env = EnvGuard::new("config-defaults");
+        let home = env.set_temp_home();
+        let config_dir = home.join(".config").join("jkl");
+        fs::create_dir_all(&config_dir).expect("create config dir");
+        fs::write(config_dir.join("jkl.toml"), "").expect("write config");
+
+        let config = load_config().expect("load config");
+
+        assert!(config.features.tui_context);
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,3 @@
-use blake3;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -705,7 +704,7 @@ mod tests {
         rename_session("sid", "New").expect("rename session");
 
         let contexts = load_contexts().expect("load contexts");
-        assert!(contexts.get(&session_key("Old")).is_none());
+        assert!(!contexts.contains_key(&session_key("Old")));
         let entry = contexts.get(&session_key("New")).expect("renamed entry");
         assert_eq!(entry.session_name.as_deref(), Some("New"));
         assert_eq!(entry.session_id.as_deref(), Some("sid"));
@@ -794,8 +793,8 @@ mod tests {
         );
 
         let contexts = load_contexts().expect("load contexts");
-        assert!(contexts.get(&session_key("old-name")).is_none());
-        assert!(contexts.get(&session_key("gone")).is_none());
+        assert!(!contexts.contains_key(&session_key("old-name")));
+        assert!(!contexts.contains_key(&session_key("gone")));
 
         let renamed = contexts
             .get(&session_key("new-name"))

--- a/src/init.rs
+++ b/src/init.rs
@@ -214,14 +214,14 @@ pub fn run_prompts(provider: Option<InitTool>, option: Option<InitPromptOption>)
 }
 
 fn render_prompts(provider: Option<InitTool>, option: Option<InitPromptOption>) -> Result<String> {
-    if let (Some(provider), Some(option)) = (provider, option) {
-        if !provider_supports_prompt_option(provider, option) {
-            return Ok(format!(
-                "{} does not support {} prompts.",
-                prompt_provider_name(provider),
-                option
-            ));
-        }
+    if let (Some(provider), Some(option)) = (provider, option)
+        && !provider_supports_prompt_option(provider, option)
+    {
+        return Ok(format!(
+            "{} does not support {} prompts.",
+            prompt_provider_name(provider),
+            option
+        ));
     }
 
     if option == Some(InitPromptOption::AgentsMd) {
@@ -366,7 +366,7 @@ fn hook_config_snippet(tool: InitTool) -> Result<String> {
         InitTool::Codex => bail!("codex does not support hooks"),
     }
 
-    Ok(serde_json::to_string_pretty(&root).context("serialize hook config")?)
+    serde_json::to_string_pretty(&root).context("serialize hook config")
 }
 
 fn resolve_tool(
@@ -808,10 +808,10 @@ fn array_field<'a>(object: &'a mut Map<String, Value>, key: &str) -> Result<&'a 
 }
 
 fn write_file_if_changed(path: &Path, content: &[u8]) -> Result<bool> {
-    if let Ok(existing) = fs::read(path) {
-        if existing == content {
-            return Ok(false);
-        }
+    if let Ok(existing) = fs::read(path)
+        && existing == content
+    {
+        return Ok(false);
     }
 
     let parent = path

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod config;
 mod context;
 mod init;
 #[cfg(test)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -16,6 +16,8 @@ use nucleo::{Config as NucleoConfig, Matcher as NucleoMatcher};
 const DATA_NOT_RECEIVED: &str = "-";
 // TODO: Will make this configurable in the future.
 const PANE_LABEL_MAX_WIDTH: usize = 10;
+const MIN_SESSION_WIDTH_WITH_CONTEXT: u16 = 20;
+const MIN_CONTEXT_WIDTH: u16 = 12;
 const INFO_TEXT: &str = "(?) help | (Esc/Ctrl+C) back/quit | (/) search | (Enter) switch | (↑/↓) move | (g/G) top/bottom | (0-9/Opt-a..z) jump | (l/h) expand/collapse | (L) toggle all | (x) delete selected | (r) refresh";
 const HELP_FEEDBACK_TEXT: &str =
     "Feedback: create an issue at https://github.com/cruzluna/jkl-2/issues";
@@ -47,6 +49,8 @@ pub enum TuiError {
     BackendFailure(String),
     #[error("{0}")]
     ContextResolutionFailure(String),
+    #[error("{0}")]
+    ConfigFailure(String),
     #[error("Search failure: {0}")]
     SearchFailure(String),
     #[error("Terminal I/O error: {0}")]
@@ -65,6 +69,12 @@ fn context_resolution_failure(source: impl std::fmt::Display) -> TuiError {
     TuiError::ContextResolutionFailure(message)
 }
 
+fn config_failure(source: impl std::fmt::Display) -> TuiError {
+    let message = source.to_string();
+    error!("tui config failure: {message}");
+    TuiError::ConfigFailure(message)
+}
+
 fn search_failure(message: String) -> TuiError {
     error!("tui search failure: {message}");
     TuiError::SearchFailure(message)
@@ -72,6 +82,12 @@ fn search_failure(message: String) -> TuiError {
 
 pub fn run() -> Result<(), TuiError> {
     info!("tui starting");
+    let config = crate::config::load_config().map_err(config_failure)?;
+    info!(
+        "tui loaded config features.tui_context={}",
+        config.features.tui_context
+    );
+
     let sessions = crate::tmux::list_sessions().map_err(backend_failure)?;
     info!(
         "tui loaded {} tmux sessions: {:?}",
@@ -88,7 +104,7 @@ pub fn run() -> Result<(), TuiError> {
     let items = build_sessions(sessions, contexts, panes);
     info!("tui built {} session rows", items.len());
 
-    let mut app = App::new(items)?;
+    let mut app = App::new(items, config.features)?;
     let mut terminal = ratatui::init();
     let result = app.run(&mut terminal);
     ratatui::restore();
@@ -310,12 +326,16 @@ struct App<S: SessionSearch> {
     mode: ListViewModes,
     expanded_sessions: HashSet<String>,
     filter: S,
+    features: crate::config::FeatureConfig,
 }
 
 impl App<NucleoSessionSearch> {
     /// Creates a list view of sessions and panes
-    fn new(sessions: Vec<SessionRow>) -> Result<Self, TuiError> {
-        Self::new_with_filter(sessions, NucleoSessionSearch::new())
+    fn new(
+        sessions: Vec<SessionRow>,
+        features: crate::config::FeatureConfig,
+    ) -> Result<Self, TuiError> {
+        Self::new_with_features_and_filter(sessions, features, NucleoSessionSearch::new())
     }
 }
 
@@ -324,6 +344,18 @@ impl<S: SessionSearch> App<S> {
     ///
     /// This keeps search behavior testable without heap allocation or dynamic dispatch.
     fn new_with_filter(sessions: Vec<SessionRow>, filter: S) -> Result<Self, TuiError> {
+        Self::new_with_features_and_filter(
+            sessions,
+            crate::config::FeatureConfig::default(),
+            filter,
+        )
+    }
+
+    fn new_with_features_and_filter(
+        sessions: Vec<SessionRow>,
+        features: crate::config::FeatureConfig,
+        filter: S,
+    ) -> Result<Self, TuiError> {
         let search_candidates = build_search_candidates(&sessions);
         let mut app = Self {
             state: TableState::default(),
@@ -342,6 +374,7 @@ impl<S: SessionSearch> App<S> {
             mode: ListViewModes::NormalMode,
             expanded_sessions: HashSet::new(),
             filter,
+            features,
         };
         app.rebuild_rows();
         app.ensure_selection();
@@ -775,9 +808,14 @@ impl<S: SessionSearch> App<S> {
     }
 
     fn render_table(&mut self, frame: &mut Frame, area: Rect) {
-        let header = Row::new(["Session", "Status", "Context"])
-            .style(Style::default().add_modifier(Modifier::BOLD));
         let widths = self.table_column_widths(area);
+        let show_context = widths.context > 0;
+        let header = if show_context {
+            Row::new(["Session", "Status", "Context"])
+        } else {
+            Row::new(["Session", "Status"])
+        }
+        .style(Style::default().add_modifier(Modifier::BOLD));
 
         let rows = self.rows.iter().enumerate().map(|(index, item)| {
             let mut base_style = if index % 2 == 0 {
@@ -788,31 +826,39 @@ impl<S: SessionSearch> App<S> {
             if matches!(item, RowItem::Pane(_)) {
                 base_style = base_style.add_modifier(Modifier::DIM);
             }
-            Row::new(vec![
+            let mut cells = vec![
                 Cell::from(truncate_with_ellipsis(
                     &self.row_label(item),
                     widths.session as usize,
                 )),
                 Cell::from(status_text(row_status(item))).style(status_style(row_status(item))),
-                Cell::from(truncate_with_ellipsis(
+            ];
+            if show_context {
+                cells.push(Cell::from(truncate_with_ellipsis(
                     &row_context(item),
                     widths.context as usize,
-                )),
-            ])
-            .style(base_style)
+                )));
+            }
+            Row::new(cells).style(base_style)
         });
 
-        let table = Table::new(
-            rows,
-            [
+        let constraints = if show_context {
+            vec![
                 Constraint::Length(widths.session),
                 Constraint::Length(widths.status),
                 Constraint::Length(widths.context),
-            ],
-        )
-        .header(header)
-        .block(Block::default().borders(Borders::ALL))
-        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+            ]
+        } else {
+            vec![
+                Constraint::Length(widths.session),
+                Constraint::Length(widths.status),
+            ]
+        };
+
+        let table = Table::new(rows, constraints)
+            .header(header)
+            .block(Block::default().borders(Borders::ALL))
+            .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
         frame.render_stateful_widget(table, area, &mut self.state);
     }
@@ -916,8 +962,12 @@ impl<S: SessionSearch> App<S> {
         #[allow(clippy::cast_possible_truncation)]
         let context_header_width = UnicodeWidthStr::width("Context") as u16;
 
-        // Account for table borders and the default one-cell spacing between three columns.
+        // Account for table borders first; column spacing depends on the visible columns.
         let inner_width = area.width.saturating_sub(2);
+        if !self.features.tui_context {
+            return self.session_status_column_widths(inner_width);
+        }
+
         let usable_width = inner_width.saturating_sub(2);
         if usable_width == 0 {
             return TableColumnWidths {
@@ -927,54 +977,58 @@ impl<S: SessionSearch> App<S> {
             };
         }
 
-        let status_width = self
-            .widths
-            .status
-            .max(status_header_width)
-            .min(usable_width);
+        let status_width = self.status_column_width(status_header_width, usable_width);
         let remaining_width = usable_width.saturating_sub(status_width);
-        if remaining_width == 0 {
-            return TableColumnWidths {
-                session: 0,
-                status: status_width,
-                context: 0,
-            };
+        let min_session_width = session_header_width
+            .max(MIN_SESSION_WIDTH_WITH_CONTEXT)
+            .min(remaining_width);
+        let min_context_width = context_header_width.max(MIN_CONTEXT_WIDTH);
+        if remaining_width < min_session_width.saturating_add(min_context_width) {
+            return self.session_status_column_widths(inner_width);
         }
 
-        // Keep session constrained so context remains visible on medium terminal widths.
-        let max_session_by_ratio = remaining_width.saturating_mul(45).saturating_div(100);
-        let min_session_width = if remaining_width > 1 {
-            session_header_width.min(remaining_width - 1)
-        } else {
-            0
-        };
-        let mut session_width = self
+        let max_session_width = remaining_width.saturating_sub(min_context_width);
+        let session_width = self
             .widths
             .session
             .max(session_header_width)
-            .min(max_session_by_ratio.max(min_session_width));
-
-        let mut context_width = remaining_width.saturating_sub(session_width);
-        let min_context_width = if remaining_width > min_session_width {
-            context_header_width.min(remaining_width - min_session_width)
-        } else {
-            0
-        };
-        if context_width < min_context_width {
-            let deficit = min_context_width - context_width;
-            session_width = session_width.saturating_sub(deficit);
-            context_width = remaining_width.saturating_sub(session_width);
-        }
-        if context_width == 0 && remaining_width > 0 {
-            context_width = 1;
-            session_width = remaining_width.saturating_sub(context_width);
-        }
+            .min(max_session_width)
+            .max(min_session_width);
+        let context_width = remaining_width.saturating_sub(session_width);
 
         TableColumnWidths {
             session: session_width,
             status: status_width,
             context: context_width,
         }
+    }
+
+    fn session_status_column_widths(&self, inner_width: u16) -> TableColumnWidths {
+        #[allow(clippy::cast_possible_truncation)]
+        let status_header_width = UnicodeWidthStr::width("Status") as u16;
+        let usable_width = inner_width.saturating_sub(1);
+        if usable_width == 0 {
+            return TableColumnWidths {
+                session: 0,
+                status: 0,
+                context: 0,
+            };
+        }
+
+        let status_width = self.status_column_width(status_header_width, usable_width);
+        let session_width = usable_width.saturating_sub(status_width);
+        TableColumnWidths {
+            session: session_width,
+            status: status_width,
+            context: 0,
+        }
+    }
+
+    fn status_column_width(&self, status_header_width: u16, usable_width: u16) -> u16 {
+        self.widths
+            .status
+            .max(status_header_width)
+            .min(usable_width)
     }
 
     fn measure_widths(&self) -> ColumnWidths {
@@ -1927,10 +1981,40 @@ esac
         let widths = app.table_column_widths(Rect::new(0, 0, 60, 10));
         assert!(widths.session < app.widths.session);
         assert!(usize::from(widths.context) >= UnicodeWidthStr::width("Context"));
+        assert!(widths.session > widths.context);
 
         let rendered_label =
             truncate_with_ellipsis(&app.row_label(&app.rows[0]), widths.session as usize);
         assert!(rendered_label.ends_with("..."));
+    }
+
+    #[test]
+    fn table_column_widths_hide_context_on_small_screens() {
+        let sessions = vec![session_row(
+            "@1",
+            "this-is-a-long-session-name-that-needs-the-space",
+        )];
+        let app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+
+        let widths = app.table_column_widths(Rect::new(0, 0, 40, 10));
+
+        assert_eq!(widths.context, 0);
+        assert!(widths.session > 0);
+        assert!(widths.status > 0);
+    }
+
+    #[test]
+    fn table_column_widths_hide_context_when_feature_disabled() {
+        let sessions = vec![session_row("@1", "alpha")];
+        let features = crate::config::FeatureConfig { tui_context: false };
+        let app = App::new_with_features_and_filter(sessions, features, passthrough_filter())
+            .expect("app");
+
+        let widths = app.table_column_widths(Rect::new(0, 0, 100, 10));
+
+        assert_eq!(widths.context, 0);
+        assert!(widths.session > 0);
+        assert!(widths.status > 0);
     }
 
     #[test]
@@ -2231,6 +2315,12 @@ esac
     fn context_resolution_failure_preserves_message() {
         let error = context_resolution_failure("failed to load contexts");
         assert_eq!(error.to_string(), "failed to load contexts");
+    }
+
+    #[test]
+    fn config_failure_preserves_message() {
+        let error = config_failure("failed to load config");
+        assert_eq!(error.to_string(), "failed to load config");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -211,6 +211,7 @@ impl RowItem {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 enum ListViewModes {
     /// Default mode when launching
     NormalMode,
@@ -343,6 +344,7 @@ impl<S: SessionSearch> App<S> {
     /// Creates a list view with an injected search backend.
     ///
     /// This keeps search behavior testable without heap allocation or dynamic dispatch.
+    #[cfg(test)]
     fn new_with_filter(sessions: Vec<SessionRow>, filter: S) -> Result<Self, TuiError> {
         Self::new_with_features_and_filter(
             sessions,
@@ -599,11 +601,11 @@ impl<S: SessionSearch> App<S> {
             self.state.select(None);
             return;
         }
-        if let Some(key) = previous {
-            if let Some(index) = self.rows.iter().position(|row| row.key() == key) {
-                self.state.select(Some(index));
-                return;
-            }
+        if let Some(key) = previous
+            && let Some(index) = self.rows.iter().position(|row| row.key() == key)
+        {
+            self.state.select(Some(index));
+            return;
         }
         self.state.select(Some(0));
     }
@@ -1511,6 +1513,8 @@ mod tests {
     #[cfg(unix)]
     use crate::test_utils::EnvGuard;
     use crate::tmux::{TmuxPane, TmuxSession};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
     use std::collections::HashMap;
     #[cfg(unix)]
     use std::fs;
@@ -1646,6 +1650,10 @@ esac
 
     fn passthrough_filter() -> PassthroughSearch {
         PassthroughSearch
+    }
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        buffer.content().iter().map(|cell| cell.symbol()).collect()
     }
 
     #[test]
@@ -2015,6 +2023,25 @@ esac
         assert_eq!(widths.context, 0);
         assert!(widths.session > 0);
         assert!(widths.status > 0);
+    }
+
+    #[test]
+    fn draw_table_omits_context_column_on_small_screens() {
+        let sessions = vec![session_row(
+            "@1",
+            "this-is-a-long-session-name-that-needs-the-space",
+        )];
+        let mut app = App::new_with_filter(sessions, passthrough_filter()).expect("app");
+        let backend = TestBackend::new(40, 6);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal.draw(|frame| app.draw(frame)).expect("draw app");
+        let text = buffer_text(terminal.backend().buffer());
+
+        assert!(text.contains("Session"));
+        assert!(text.contains("Status"));
+        assert!(!text.contains("Context"));
+        assert!(!text.contains("ctx"));
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -95,10 +95,10 @@ fn is_amazon_linux_2_from_os_release(contents: &str) -> bool {
 }
 
 fn is_amazon_linux_2() -> bool {
-    if let Ok(os_release) = fs::read_to_string("/etc/os-release") {
-        if is_amazon_linux_2_from_os_release(&os_release) {
-            return true;
-        }
+    if let Ok(os_release) = fs::read_to_string("/etc/os-release")
+        && is_amazon_linux_2_from_os_release(&os_release)
+    {
+        return true;
     }
 
     if let Ok(system_release) = fs::read_to_string("/etc/system-release") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `~/.config/jkl/jkl.toml` with `[features] tui_context` for toggling the TUI Context column.
- Hide the Context column automatically on narrow TUI widths and prioritize session/status columns.
- Add config and rendered TUI coverage for the context-free view, plus documentation for the new setting.

### Testing
- `cargo +stable fmt --all -- --check`
- `cargo +stable test --locked tui::tests::draw_table_omits_context_column_on_small_screens -- --exact`
- `cargo +stable test --locked`
- `cargo +stable clippy --all-targets -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45625ab5-6318-4331-b254-795ce7e52f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45625ab5-6318-4331-b254-795ce7e52f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

