### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,11 @@ Use this as the default playbook for coding agents in this repository.
 - Defer to runtime tmux values for targeting and navigation. Session/window/pane IDs can change after tmux resurrect or restart.
 - Treat persisted context IDs as advisory metadata. Re-resolve live IDs from tmux (`list-sessions`, `list-panes`, pane targets) before executing switch/select commands.
 - Use conventional commit messages
+
+## Cursor Cloud specific instructions
+
+- **Rust toolchain**: The project uses `edition = "2024"` which requires Rust >= 1.85. The update script runs `rustup update stable && rustup default stable` to ensure this.
+- **tmux**: Required at runtime. The VM has tmux pre-installed. The TUI (`cargo run -- tui`) must be launched inside a tmux session. Tests mock tmux and do not need a running tmux server.
+- **Clippy with `-D warnings`**: The codebase has pre-existing `unnecessary_get_then_check` warnings that surface on Rust >= 1.95. Use `cargo clippy --all-targets` (without `-D warnings`) to check for new issues if the upstream warnings haven't been fixed yet.
+- **Session context**: Written to `~/.config/jkl/session_context.json`. Tests isolate this with `EnvGuard` temp directories.
+- **All standard build/test/lint commands** are listed in the "Build, Test, Lint" section above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment notes for future cloud agents:

- Rust edition 2024 requires >= 1.85 toolchain
- tmux runtime requirement and TUI launch caveat
- Pre-existing clippy warnings on Rust >= 1.95
- Session context file location and test isolation

**Environment verification:**

[dev_environment_output.log](https://cursor.com/agents/bc-418b9126-4d99-4122-94c6-5a6d481ede47/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_output.log)

All 102 tests pass, formatting is clean, and both CLI and TUI modes are functional.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-418b9126-4d99-4122-94c6-5a6d481ede47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-418b9126-4d99-4122-94c6-5a6d481ede47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

