### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,11 @@ Use this as the default playbook for coding agents in this repository.
 - Defer to runtime tmux values for targeting and navigation. Session/window/pane IDs can change after tmux resurrect or restart.
 - Treat persisted context IDs as advisory metadata. Re-resolve live IDs from tmux (`list-sessions`, `list-panes`, pane targets) before executing switch/select commands.
 - Use conventional commit messages
+
+## Cursor Cloud specific instructions
+
+- The project uses Rust edition 2024 (`Cargo.toml`), which requires Rust >= 1.85.0. The update script runs `rustup update stable` to keep the toolchain current.
+- `cargo clippy --all-targets -- -D warnings` produces pre-existing warnings on Rust >= 1.95 (`unnecessary_get_then_check`). These are not regressions; `cargo clippy --all-targets` (without `-D warnings`) is the practical lint check.
+- The TUI (`cargo run -- tui`) requires a tmux server with at least one session. Start a tmux session before launching the TUI, or tests that depend on live tmux will fail.
+- Tests use `EnvGuard` with temp directories and a fake tmux script, so `cargo test --locked` works without a running tmux server.
+- Session metadata is stored at `~/.config/jkl/session_context.json` (created automatically on first run).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment notes for future cloud agents:

- Rust edition 2024 requires >= 1.85 toolchain (update script handles this)
- Pre-existing clippy warnings on Rust >= 1.95 (not regressions)
- tmux runtime requirement for TUI and test isolation via `EnvGuard`
- Session context file location

**Environment verification:**

[dev_environment_output.log](https://cursor.com/agents/bc-b2a8c53b-219b-4c57-93b5-cfe7ff4af897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_output.log)

All 102 tests pass, formatting is clean, and both CLI and TUI modes are functional.

**TUI output showing 3 sessions with different statuses:**
[tui_output.txt](https://cursor.com/agents/bc-b2a8c53b-219b-4c57-93b5-cfe7ff4af897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_output.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2a8c53b-219b-4c57-93b5-cfe7ff4af897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2a8c53b-219b-4c57-93b5-cfe7ff4af897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

