### PR TITLE
[codex] make TUI popup size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ set -g @jkl_key_pane_state 'P'
 set -g @jkl_key_edit 'none'
 ```
 
+You can configure the agent view popup size. Width and height accept tmux popup dimensions, including integer cells or percentages. Defaults are `40%` by `40%`.
+
+```tmux
+set -g @jkl_agent_view_popup_width '80'
+set -g @jkl_agent_view_popup_height '20'
+```
+
 By default the plugin does not override existing tmux/user bindings. Recommended for a fresh setup: force the jkl defaults to bind even if tmux already has a key there:
 
 ```tmux

--- a/jkl.tmux
+++ b/jkl.tmux
@@ -12,6 +12,19 @@ get_tmux_option() {
   fi
 }
 
+get_tmux_popup_dimension() {
+  local option="$1"
+  local default="$2"
+  local value
+
+  value="$(get_tmux_option "$option" "$default")"
+  if [[ "$value" =~ ^[0-9]+%?$ ]]; then
+    echo "$value"
+  else
+    echo "$default"
+  fi
+}
+
 resolve_binding_key() {
   local option_name="$1"
   local default_key="$2"
@@ -65,7 +78,10 @@ bind_prefix_key() {
   tmux bind-key "$key" "$@"
 }
 
-bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" display-popup -E -w 40% -h 40% "jkl tui"
+agent_view_popup_width="$(get_tmux_popup_dimension "@jkl_agent_view_popup_width" "40%")"
+agent_view_popup_height="$(get_tmux_popup_dimension "@jkl_agent_view_popup_height" "40%")"
+
+bind_prefix_key "@jkl_key_agent_view" "f" "@jkl_key_tui" display-popup -E -w "$agent_view_popup_width" -h "$agent_view_popup_height" "jkl tui"
 bind_prefix_key "@jkl_key_context" "W" command-prompt -p "Context for #S:" "run-shell \"jkl upsert '#S' --session-id '#{session_id}' --context '%%'\""
 bind_prefix_key "@jkl_key_edit" "e" display-popup -E -w 40% -h 40% "nvim ~/.config/jkl/session_context.json"
 bind_prefix_key "@jkl_key_pane_state" "S" run-shell 'tmux display-popup -E -w 30% -h 20% "jkl tui --pane-state --session-name \"#{session_name}\" --pane-id \"#{pane_id}\""'

--- a/src/init.rs
+++ b/src/init.rs
@@ -24,6 +24,10 @@ const TMUX_CONF_LINES: [&str; 3] = [
     "set -g @jkl_force_bind_keys 'on'",
     "run '~/.tmux/plugins/tpm/tpm'",
 ];
+const TMUX_CONF_OPTIONAL_LINES: [&str; 2] = [
+    "set -g @jkl_agent_view_popup_width '80'",
+    "set -g @jkl_agent_view_popup_height '20'",
+];
 const AGENTS_MD_APPEND_LINES: [&str; 10] = [
     "## jkl",
     "- When working inside tmux, use `jkl upsert` to keep jkl metadata current.",
@@ -314,9 +318,14 @@ fn render_agents_append_snippet() -> String {
 
 fn render_tmux_prompt(tools: &[InitTool]) -> String {
     format!(
-        "tmux.conf\n\nProviders: {}\nAdd these lines to `~/.tmux.conf`:\n{}\nThen reload tmux. If TPM still needs to install the plugin, run:\n{}\nAfter reloading, open the list right away with `<prefix> f` (or your configured agent view key).",
+        "tmux.conf\n\nProviders: {}\nAdd these lines to `~/.tmux.conf`:\n{}\nOptional agent view popup size overrides:\n{}\nThen reload tmux. If TPM still needs to install the plugin, run:\n{}\nAfter reloading, open the list right away with `<prefix> f` (or your configured agent view key).",
         render_tool_list(tools),
         TMUX_CONF_LINES
+            .iter()
+            .map(|line| format!("- {line}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        TMUX_CONF_OPTIONAL_LINES
             .iter()
             .map(|line| format!("- {line}"))
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- Add tmux options for configuring the main `jkl tui` agent-view popup opened with `<prefix> f`.
- Preserve the existing `40%` by `40%` defaults when options are unset or invalid.
- Document the new `.tmux.conf` settings and include them in `jkl init prompts --option tmux.conf`.

## Configuration
```tmux
set -g @jkl_agent_view_popup_width 80
set -g @jkl_agent_view_popup_height 20
```

## Validation
- `bash -n jkl.tmux`
- `cargo fmt --all`
- `cargo test init::tests`
- `cargo test --locked`