### PR TITLE
feat: update agent status vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Use this as the default playbook for coding agents in this repository.
 - Build:`cargo build`
 - Run:
 - `cargo run -- tui`
-- `cargo run -- upsert my session --status working`
+- `cargo run -- upsert my session --status idle`
 - Test all:
 - `cargo test --locked`
 - Test one module:

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ set -g @jkl_force_bind_keys 'on'
 
 ### Claude Code hooks
 
-Claude Code hooks can be configured in `~/.claude/settings.json` (user), `.claude/settings.json` (project), or `.claude/settings.local.json` (local project). The example below marks the current tmux pane as `working` when you submit a prompt, and `idle` when Claude stops.
+Claude Code hooks can be configured in `~/.claude/settings.json` (user), `.claude/settings.json` (project), or `.claude/settings.local.json` (local project). The example below marks the current tmux pane as `working` when you submit a prompt, `blocked` while Claude waits on user input or permission, and `idle` when Claude stops.
 
 Initialize automatically:
 
@@ -250,6 +250,27 @@ jkl init hooks --tool claude --scope global --non-interactive
           {
             "type": "command",
             "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt|elicitation_dialog",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked"
           }
         ]
       }
@@ -275,7 +296,7 @@ Docs:
 
 ### Kiro CLI hooks
 
-Kiro CLI hooks are defined in an agent config file (for example `.kiro/agents/jkl.json` in a project, or `~/.kiro/agents/jkl.json` globally). The same pattern can be applied with `userPromptSubmit` and `stop` hooks:
+Kiro CLI hooks are defined in an agent config file (for example `.kiro/agents/jkl.json` in a project, or `~/.kiro/agents/jkl.json` globally). The same pattern can be applied with `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop` hooks:
 
 Initialize automatically:
 
@@ -312,6 +333,16 @@ Kiro hooks targeting behavior:
         "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
       }
     ],
+    "preToolUse": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked"
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
+      }
+    ],
     "stop": [
       {
         "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle"
@@ -332,7 +363,7 @@ Docs:
 
 Cursor hooks are configured in `hooks.json` at either the user level (`~/.cursor/hooks.json`) or the project level (`<project>/.cursor/hooks.json`).
 
-The example below uses Agent hooks to mirror the Kiro behavior: set the current tmux pane to `working` on `beforeSubmitPrompt`, then back to `idle` on `stop`.
+The example below uses Agent hooks to mirror the Kiro behavior: set the current tmux pane to `working` on `beforeSubmitPrompt`, `blocked` before shell or MCP actions that may need approval, then back to `idle` on `stop`.
 
 Initialize automatically:
 
@@ -356,6 +387,26 @@ Cursor hooks targeting behavior:
   "version": 1,
   "hooks": {
     "beforeSubmitPrompt": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked"
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
+      }
+    ],
+    "beforeMCPExecution": [
+      {
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked"
+      }
+    ],
+    "afterMCPExecution": [
       {
         "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working"
       }

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ set -g @jkl_force_bind_keys 'on'
 
 ### Claude Code hooks
 
-Claude Code hooks can be configured in `~/.claude/settings.json` (user), `.claude/settings.json` (project), or `.claude/settings.local.json` (local project). The example below marks the current tmux pane as `working` when you submit a prompt, and `waiting` when Claude stops.
+Claude Code hooks can be configured in `~/.claude/settings.json` (user), `.claude/settings.json` (project), or `.claude/settings.local.json` (local project). The example below marks the current tmux pane as `working` when you submit a prompt, and `idle` when Claude stops.
 
 Initialize automatically:
 
@@ -259,7 +259,7 @@ jkl init hooks --tool claude --scope global --non-interactive
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting"
+            "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle"
           }
         ]
       }
@@ -314,7 +314,7 @@ Kiro hooks targeting behavior:
     ],
     "stop": [
       {
-        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting"
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle"
       }
     ]
   }
@@ -332,7 +332,7 @@ Docs:
 
 Cursor hooks are configured in `hooks.json` at either the user level (`~/.cursor/hooks.json`) or the project level (`<project>/.cursor/hooks.json`).
 
-The example below uses Agent hooks to mirror the Kiro behavior: set the current tmux pane to `working` on `beforeSubmitPrompt`, then back to `waiting` on `stop`.
+The example below uses Agent hooks to mirror the Kiro behavior: set the current tmux pane to `working` on `beforeSubmitPrompt`, then back to `idle` on `stop`.
 
 Initialize automatically:
 
@@ -362,7 +362,7 @@ Cursor hooks targeting behavior:
     ],
     "stop": [
       {
-        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting"
+        "command": "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle"
       }
     ]
   }
@@ -401,7 +401,7 @@ Shape (keyed by `blake3(session_name)`):
 {
   "2f0d7b3b5e3b9b1d4b4b5b8b8e2e2e9a2d2d4d5f2f0f5e5f2d9b3f1a5c8e": {
     "session_name": "work",
-    "session_status": "waiting",
+    "session_status": "idle",
     "session_context": "my project",
     "windows": {
       "@10": {
@@ -439,8 +439,9 @@ jkl sync
 Status values:
 
 - `working` (blue)
-- `waiting` or `idle` (yellow)
-- `done` (green)
+- `idle` (yellow)
+- `blocked` (red)
+- `unknown` (gray)
 - missing values render as `-`
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ jkl sync
 
 Status values:
 
-- `working` (blue)
 - `idle` (yellow)
+- `working` (blue)
 - `blocked` (red)
 - `unknown` (gray)
 - missing values render as `-`

--- a/completions/fig/jkl.ts
+++ b/completions/fig/jkl.ts
@@ -1,8 +1,8 @@
 const statusSuggestions: Fig.Suggestion[] = [
+  { name: "idle", description: "Agent is idle or ready for review" },
   { name: "working", description: "Agent is actively working" },
-  { name: "waiting", description: "Agent is waiting for human input" },
-  { name: "done", description: "Agent has completed the task" },
-  { name: "none", description: "Clear status / no explicit status" },
+  { name: "blocked", description: "Agent is waiting for human input" },
+  { name: "unknown", description: "Agent status is unknown" },
 ];
 
 const initToolHooksSuggestions: Fig.Suggestion[] = [

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ fi
 printf "\n"
 
 WORKING_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status working'
-WAITING_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status waiting'
+IDLE_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status idle'
 
 RULE_LINE="──────────────────────────────────────────────────────────────"
 print_message muted "$RULE_LINE"
@@ -189,19 +189,19 @@ print_message muted "  jkl init fig-autocomplete"
 printf "\n"
 
 print_message accent "▸ Claude Code hooks"
-print_message muted "  Paste into Claude Code so the current pane is \"working\" while you prompt and \"waiting\" when Claude stops."
+print_message muted "  Paste into Claude Code so the current pane is \"working\" while you prompt and \"idle\" when Claude stops."
 print_message muted "  UserPromptSubmit:"
 print_message info "      $WORKING_HOOK_COMMAND"
 print_message muted "  Stop:"
-print_message info "      $WAITING_HOOK_COMMAND"
+print_message info "      $IDLE_HOOK_COMMAND"
 printf "\n"
 
 print_message accent "▸ Kiro CLI hooks"
-print_message muted "  Paste into Kiro CLI for the same working / waiting behavior."
+print_message muted "  Paste into Kiro CLI for the same working / idle behavior."
 print_message muted "  userPromptSubmit:"
 print_message info "      $WORKING_HOOK_COMMAND"
 print_message muted "  stop:"
-print_message info "      $WAITING_HOOK_COMMAND"
+print_message info "      $IDLE_HOOK_COMMAND"
 printf "\n"
 
 print_message accent "▸ tmux + TPM"

--- a/install.sh
+++ b/install.sh
@@ -174,6 +174,7 @@ fi
 printf "\n"
 
 WORKING_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status working'
+BLOCKED_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status blocked'
 IDLE_HOOK_COMMAND='[ -n "$TMUX" ] || exit 0; jkl upsert "$(tmux display-message -p '"'"'#S'"'"')" --session-id "$(tmux display-message -p '"'"'#{session_id}'"'"')" --pane-id "$(tmux display-message -p '"'"'#{pane_id}'"'"')" --status idle'
 
 RULE_LINE="──────────────────────────────────────────────────────────────"
@@ -192,13 +193,19 @@ print_message accent "▸ Claude Code hooks"
 print_message muted "  Paste into Claude Code so the current pane is \"working\" while you prompt and \"idle\" when Claude stops."
 print_message muted "  UserPromptSubmit:"
 print_message info "      $WORKING_HOOK_COMMAND"
+print_message muted "  PermissionRequest / Notification permission prompts:"
+print_message info "      $BLOCKED_HOOK_COMMAND"
 print_message muted "  Stop:"
 print_message info "      $IDLE_HOOK_COMMAND"
 printf "\n"
 
 print_message accent "▸ Kiro CLI hooks"
-print_message muted "  Paste into Kiro CLI for the same working / idle behavior."
+print_message muted "  Paste into Kiro CLI for working / blocked / idle behavior."
 print_message muted "  userPromptSubmit:"
+print_message info "      $WORKING_HOOK_COMMAND"
+print_message muted "  preToolUse:"
+print_message info "      $BLOCKED_HOOK_COMMAND"
+print_message muted "  postToolUse:"
 print_message info "      $WORKING_HOOK_COMMAND"
 print_message muted "  stop:"
 print_message info "      $IDLE_HOOK_COMMAND"

--- a/install.sh
+++ b/install.sh
@@ -190,7 +190,7 @@ print_message muted "  jkl init fig-autocomplete"
 printf "\n"
 
 print_message accent "▸ Claude Code hooks"
-print_message muted "  Paste into Claude Code so the current pane is \"working\" while you prompt and \"idle\" when Claude stops."
+print_message muted "  Paste into Claude Code so the current pane is \"working\" while you prompt, \"blocked\" for permission/user prompts, and \"idle\" when Claude stops."
 print_message muted "  UserPromptSubmit:"
 print_message info "      $WORKING_HOOK_COMMAND"
 print_message muted "  PermissionRequest / Notification permission prompts:"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ Examples:
   jkl upsert \"$(tmux display-message -p '#S')\" \\
     --session-id \"$(tmux display-message -p '#{session_id}')\" \\
     --pane-id \"$(tmux display-message -p '#{pane_id}')\" \\
-    --status waiting
+    --status idle
 
   # Pane labels + short context
   jkl upsert \"$(tmux display-message -p '#S')\" \\
@@ -100,7 +100,7 @@ struct UpsertArgs {
     /// Human-readable pane label (set once, then reuse).
     #[arg(long)]
     pane_name: Option<String>,
-    /// One of: working, waiting, done, none.
+    /// One of: idle, working, blocked, unknown.
     #[arg(long)]
     status: Option<String>,
     /// Short context note (prefer a few words).
@@ -343,7 +343,7 @@ fn join_tokens(tokens: Vec<String>) -> String {
 }
 
 fn valid_statuses() -> Vec<&'static str> {
-    vec!["working", "waiting", "done", "none"]
+    vec!["idle", "working", "blocked", "unknown"]
 }
 
 #[cfg(test)]
@@ -383,7 +383,7 @@ mod tests {
             ContextError::InvalidStatus(message) => {
                 assert_eq!(
                     message,
-                    "not-a-status. Valid options: working, waiting, done, none"
+                    "not-a-status. Valid options: idle, working, blocked, unknown"
                 );
             }
             other => panic!("unexpected error: {other:?}"),
@@ -470,7 +470,7 @@ mod tests {
             window_id: Some("@1".to_string()),
             pane_name: Some("planner".to_string()),
             window_name: Some("editor".to_string()),
-            status: Some("waiting".to_string()),
+            status: Some("idle".to_string()),
             context: Some(vec!["pane".to_string(), "ctx".to_string()]),
         };
 
@@ -482,7 +482,7 @@ mod tests {
         assert_eq!(pane.window_id.as_deref(), Some("@1"));
         assert_eq!(pane.window_name.as_deref(), Some("editor"));
         assert_eq!(pane.pane_name.as_deref(), Some("planner"));
-        assert_eq!(pane.pane_status, Some(AgentStatus::Waiting));
+        assert_eq!(pane.pane_status, Some(AgentStatus::Idle));
         assert_eq!(pane.pane_context.as_deref(), Some("pane ctx"));
     }
 
@@ -498,7 +498,7 @@ mod tests {
             window_id: None,
             window_name: Some("editor".to_string()),
             pane_name: None,
-            status: Some("waiting".to_string()),
+            status: Some("idle".to_string()),
             context: None,
         };
 
@@ -519,7 +519,7 @@ mod tests {
         crate::context::upsert_session(
             "Alpha".to_string(),
             Some("@1".to_string()),
-            Some(AgentStatus::Done),
+            Some(AgentStatus::Unknown),
             Some("keep session ctx".to_string()),
         )
         .expect("seed session");
@@ -541,7 +541,7 @@ mod tests {
             window_id: None,
             window_name: None,
             pane_name: None,
-            status: Some("waiting".to_string()),
+            status: Some("blocked".to_string()),
             context: None,
         };
         handle_upsert(args).expect("upsert pane status");
@@ -549,10 +549,10 @@ mod tests {
         let contexts = load_contexts().expect("load contexts");
         let session = contexts.get(&session_key("Alpha")).expect("session exists");
         assert_eq!(session.session_context.as_deref(), Some("keep session ctx"));
-        assert_eq!(session.session_status, Some(AgentStatus::Done));
+        assert_eq!(session.session_status, Some(AgentStatus::Unknown));
 
         let pane = session.panes.get("%1").expect("pane exists");
-        assert_eq!(pane.pane_status, Some(AgentStatus::Waiting));
+        assert_eq!(pane.pane_status, Some(AgentStatus::Blocked));
         assert_eq!(pane.pane_context.as_deref(), Some("keep pane ctx"));
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,14 +14,18 @@ use thiserror::Error;
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum AgentStatus {
-    // When the Agent is working
+    // When the agent is waiting for new work or review.
+    #[serde(alias = "waiting", alias = "done")]
+    #[strum(to_string = "idle", serialize = "waiting", serialize = "done")]
+    Idle,
+    // When the agent is actively working.
     Working,
-    // When the Agent is waiting for human intervention
-    Waiting,
-    // When the Agent is complete with its work
-    Done,
-    // When there is no status assigned to an Agent or the Agent DNE yet
-    None,
+    // When the agent needs human input or permission to proceed.
+    Blocked,
+    // When the agent status is explicitly unknown.
+    #[serde(alias = "none")]
+    #[strum(to_string = "unknown", serialize = "none")]
+    Unknown,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
@@ -104,35 +108,34 @@ where
         return override_status;
     }
 
-    let mut working = 0usize;
-    let mut waiting = 0usize;
-    let mut done = 0usize;
+    let mut blocked = false;
+    let mut working = false;
+    let mut idle = false;
+    let mut unknown = false;
 
     for status in pane_statuses {
         let Some(status) = status else {
             continue;
         };
         match status {
-            AgentStatus::None => {}
-            AgentStatus::Working => working += 1,
-            // "idle" maps to Waiting in AgentStatus terms.
-            AgentStatus::Waiting => waiting += 1,
-            AgentStatus::Done => done += 1,
+            AgentStatus::Blocked => blocked = true,
+            AgentStatus::Working => working = true,
+            AgentStatus::Idle => idle = true,
+            AgentStatus::Unknown => unknown = true,
         }
     }
 
-    if working == 0 && waiting == 0 && done == 0 {
-        return None;
+    if blocked {
+        return Some(AgentStatus::Blocked);
     }
-
-    if working > 0 {
+    if working {
         return Some(AgentStatus::Working);
     }
-    if waiting > 0 {
-        return Some(AgentStatus::Waiting);
+    if idle {
+        return Some(AgentStatus::Idle);
     }
-    if done > 0 {
-        return Some(AgentStatus::Done);
+    if unknown {
+        return Some(AgentStatus::Unknown);
     }
 
     None
@@ -580,29 +583,57 @@ mod tests {
     }
 
     #[test]
-    fn effective_session_status_prioritizes_non_done_pane_states() {
+    fn effective_session_status_prioritizes_blocked_then_working_then_idle() {
         let status = effective_session_status(
             None,
-            vec![Some(AgentStatus::Done), Some(AgentStatus::Waiting)],
+            vec![Some(AgentStatus::Unknown), Some(AgentStatus::Idle)],
         );
-        assert_eq!(status, Some(AgentStatus::Waiting));
+        assert_eq!(status, Some(AgentStatus::Idle));
 
         let status = effective_session_status(
             None,
             vec![
-                Some(AgentStatus::Done),
-                Some(AgentStatus::Waiting),
+                Some(AgentStatus::Unknown),
+                Some(AgentStatus::Idle),
                 Some(AgentStatus::Working),
             ],
         );
         assert_eq!(status, Some(AgentStatus::Working));
+
+        let status = effective_session_status(
+            None,
+            vec![
+                Some(AgentStatus::Working),
+                Some(AgentStatus::Blocked),
+                Some(AgentStatus::Idle),
+            ],
+        );
+        assert_eq!(status, Some(AgentStatus::Blocked));
     }
 
     #[test]
-    fn effective_session_status_is_done_only_when_all_known_panes_are_done() {
-        let status =
-            effective_session_status(None, vec![Some(AgentStatus::Done), Some(AgentStatus::Done)]);
-        assert_eq!(status, Some(AgentStatus::Done));
+    fn effective_session_status_uses_unknown_when_only_unknown_is_reported() {
+        let status = effective_session_status(None, vec![Some(AgentStatus::Unknown), None]);
+        assert_eq!(status, Some(AgentStatus::Unknown));
+    }
+
+    #[test]
+    fn agent_status_reads_legacy_values_as_new_statuses() {
+        assert_eq!("waiting".parse::<AgentStatus>(), Ok(AgentStatus::Idle));
+        assert_eq!("done".parse::<AgentStatus>(), Ok(AgentStatus::Idle));
+        assert_eq!("none".parse::<AgentStatus>(), Ok(AgentStatus::Unknown));
+
+        let idle: AgentStatus = serde_json::from_str("\"waiting\"").expect("legacy waiting");
+        let done: AgentStatus = serde_json::from_str("\"done\"").expect("legacy done");
+        let unknown: AgentStatus = serde_json::from_str("\"none\"").expect("legacy none");
+
+        assert_eq!(idle, AgentStatus::Idle);
+        assert_eq!(done, AgentStatus::Idle);
+        assert_eq!(unknown, AgentStatus::Unknown);
+        assert_eq!(
+            serde_json::to_string(&AgentStatus::Idle).expect("serialize idle"),
+            "\"idle\""
+        );
     }
 
     #[test]
@@ -650,7 +681,7 @@ mod tests {
             None,
             None,
             Some("pane".to_string()),
-            Some(AgentStatus::Waiting),
+            Some(AgentStatus::Idle),
             Some("ctx".to_string()),
         )
         .expect("upsert pane");
@@ -659,7 +690,7 @@ mod tests {
         let session = contexts.get(&session_key("Alpha")).expect("session entry");
         let pane = session.panes.get("%1").expect("pane entry");
         assert_eq!(pane.pane_name.as_deref(), Some("pane"));
-        assert_eq!(pane.pane_status, Some(AgentStatus::Waiting));
+        assert_eq!(pane.pane_status, Some(AgentStatus::Idle));
         assert_eq!(pane.pane_context.as_deref(), Some("ctx"));
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,11 +9,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const CLAUDE_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
-const CLAUDE_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const CLAUDE_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 const KIRO_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
-const KIRO_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const KIRO_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 const CURSOR_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
-const CURSOR_WAITING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const CURSOR_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 
 const KIRO_NAME: &str = "jkl";
 const KIRO_DESCRIPTION: &str = "Sync jkl status with Kiro activity";
@@ -37,7 +37,7 @@ const AGENTS_MD_APPEND_LINES: [&str; 10] = [
     "  - Pane id: `$(tmux display-message -p '#{pane_id}')`",
     "- Pane example: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working`",
     "- Pane context example: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --context \"triage auth bug\"`",
-    "- Session example: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --status waiting --context \"need review\"`",
+    "- Session example: `jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --status idle --context \"need review\"`",
     "- If you update session or pane context, keep it under 10 words.",
 ];
 const ALL_PROMPT_TOOLS: [InitTool; 4] = [
@@ -676,7 +676,7 @@ fn write_json_pretty(path: &Path, value: &Value) -> Result<()> {
 fn ensure_claude_hooks(root: &mut Value) -> Result<bool> {
     let mut changed = false;
     changed |= ensure_claude_hook(root, "UserPromptSubmit", CLAUDE_WORKING_COMMAND)?;
-    changed |= ensure_claude_hook(root, "Stop", CLAUDE_WAITING_COMMAND)?;
+    changed |= ensure_claude_hook(root, "Stop", CLAUDE_IDLE_COMMAND)?;
     Ok(changed)
 }
 
@@ -737,7 +737,7 @@ fn ensure_kiro_hooks(root: &mut Value) -> Result<bool> {
 
     let hooks = object_field(root_obj, "hooks")?;
     changed |= ensure_kiro_hook_event(hooks, "userPromptSubmit", KIRO_WORKING_COMMAND)?;
-    changed |= ensure_kiro_hook_event(hooks, "stop", KIRO_WAITING_COMMAND)?;
+    changed |= ensure_kiro_hook_event(hooks, "stop", KIRO_IDLE_COMMAND)?;
 
     Ok(changed)
 }
@@ -773,7 +773,7 @@ fn ensure_cursor_hooks(root: &mut Value) -> Result<bool> {
 
     let hooks = object_field(root_obj, "hooks")?;
     changed |= ensure_cursor_hook_event(hooks, "beforeSubmitPrompt", CURSOR_WORKING_COMMAND)?;
-    changed |= ensure_cursor_hook_event(hooks, "stop", CURSOR_WAITING_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "stop", CURSOR_IDLE_COMMAND)?;
     Ok(changed)
 }
 
@@ -1122,7 +1122,7 @@ mod tests {
             .expect("render hooks");
         assert!(rendered.contains("UserPromptSubmit"));
         assert!(rendered.contains("--status working"));
-        assert!(rendered.contains("--status waiting"));
+        assert!(rendered.contains("--status idle"));
         assert!(rendered.contains(".claude/settings.local.json"));
         assert!(rendered.contains("~/.claude/settings.json"));
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,10 +9,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const CLAUDE_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const CLAUDE_BLOCKED_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked";
 const CLAUDE_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 const KIRO_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const KIRO_BLOCKED_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked";
 const KIRO_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 const CURSOR_WORKING_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const CURSOR_BLOCKED_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked";
 const CURSOR_IDLE_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 
 const KIRO_NAME: &str = "jkl";
@@ -675,36 +678,57 @@ fn write_json_pretty(path: &Path, value: &Value) -> Result<()> {
 
 fn ensure_claude_hooks(root: &mut Value) -> Result<bool> {
     let mut changed = false;
-    changed |= ensure_claude_hook(root, "UserPromptSubmit", CLAUDE_WORKING_COMMAND)?;
-    changed |= ensure_claude_hook(root, "Stop", CLAUDE_IDLE_COMMAND)?;
+    changed |= ensure_claude_hook(root, "UserPromptSubmit", None, CLAUDE_WORKING_COMMAND)?;
+    changed |= ensure_claude_hook(root, "PermissionRequest", None, CLAUDE_BLOCKED_COMMAND)?;
+    changed |= ensure_claude_hook(
+        root,
+        "Notification",
+        Some("permission_prompt|idle_prompt|elicitation_dialog"),
+        CLAUDE_BLOCKED_COMMAND,
+    )?;
+    changed |= ensure_claude_hook(root, "Stop", None, CLAUDE_IDLE_COMMAND)?;
     Ok(changed)
 }
 
-fn ensure_claude_hook(root: &mut Value, event: &str, command: &str) -> Result<bool> {
+fn ensure_claude_hook(
+    root: &mut Value,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
+) -> Result<bool> {
     let root_obj = root
         .as_object_mut()
         .context("claude config root must be a JSON object")?;
     let hooks = object_field(root_obj, "hooks")?;
     let event_entries = array_field(hooks, event)?;
 
-    if claude_event_contains_command(event_entries, command) {
+    if claude_event_contains_command(event_entries, matcher, command) {
         return Ok(false);
     }
 
-    event_entries.push(json!({
+    let mut entry = json!({
         "hooks": [
             {
                 "type": "command",
                 "command": command
             }
         ]
-    }));
+    });
+    if let Some(matcher) = matcher
+        && let Some(entry_obj) = entry.as_object_mut()
+    {
+        entry_obj.insert("matcher".to_string(), Value::String(matcher.to_string()));
+    }
+    event_entries.push(entry);
 
     Ok(true)
 }
 
-fn claude_event_contains_command(entries: &[Value], command: &str) -> bool {
+fn claude_event_contains_command(entries: &[Value], matcher: Option<&str>, command: &str) -> bool {
     entries.iter().any(|entry| {
+        if entry.get("matcher").and_then(Value::as_str) != matcher {
+            return false;
+        }
         entry
             .get("hooks")
             .and_then(Value::as_array)
@@ -737,6 +761,8 @@ fn ensure_kiro_hooks(root: &mut Value) -> Result<bool> {
 
     let hooks = object_field(root_obj, "hooks")?;
     changed |= ensure_kiro_hook_event(hooks, "userPromptSubmit", KIRO_WORKING_COMMAND)?;
+    changed |= ensure_kiro_hook_event(hooks, "preToolUse", KIRO_BLOCKED_COMMAND)?;
+    changed |= ensure_kiro_hook_event(hooks, "postToolUse", KIRO_WORKING_COMMAND)?;
     changed |= ensure_kiro_hook_event(hooks, "stop", KIRO_IDLE_COMMAND)?;
 
     Ok(changed)
@@ -773,6 +799,10 @@ fn ensure_cursor_hooks(root: &mut Value) -> Result<bool> {
 
     let hooks = object_field(root_obj, "hooks")?;
     changed |= ensure_cursor_hook_event(hooks, "beforeSubmitPrompt", CURSOR_WORKING_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "beforeShellExecution", CURSOR_BLOCKED_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "afterShellExecution", CURSOR_WORKING_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "beforeMCPExecution", CURSOR_BLOCKED_COMMAND)?;
+    changed |= ensure_cursor_hook_event(hooks, "afterMCPExecution", CURSOR_WORKING_COMMAND)?;
     changed |= ensure_cursor_hook_event(hooks, "stop", CURSOR_IDLE_COMMAND)?;
     Ok(changed)
 }
@@ -986,6 +1016,20 @@ mod tests {
             .and_then(Value::as_array)
             .expect("submit array");
         assert_eq!(submit.len(), 1);
+        let permission_request = hooks
+            .get("PermissionRequest")
+            .and_then(Value::as_array)
+            .expect("permission request array");
+        assert_eq!(permission_request.len(), 1);
+        let notification = hooks
+            .get("Notification")
+            .and_then(Value::as_array)
+            .expect("notification array");
+        assert_eq!(notification.len(), 1);
+        assert_eq!(
+            notification[0].get("matcher").and_then(Value::as_str),
+            Some("permission_prompt|idle_prompt|elicitation_dialog")
+        );
     }
 
     #[test]
@@ -1007,6 +1051,15 @@ mod tests {
             .and_then(Value::as_array)
             .expect("stop array");
         assert_eq!(stop.len(), 1);
+        let pre_tool = hooks
+            .get("preToolUse")
+            .and_then(Value::as_array)
+            .expect("preToolUse array");
+        assert_eq!(pre_tool.len(), 1);
+        assert_eq!(
+            pre_tool[0].get("command").and_then(Value::as_str),
+            Some(KIRO_BLOCKED_COMMAND)
+        );
     }
 
     #[test]
@@ -1034,6 +1087,15 @@ mod tests {
             .and_then(Value::as_array)
             .expect("beforeSubmitPrompt array");
         assert_eq!(submit.len(), 1);
+        let before_shell = hooks
+            .get("beforeShellExecution")
+            .and_then(Value::as_array)
+            .expect("beforeShellExecution array");
+        assert_eq!(before_shell.len(), 1);
+        assert_eq!(
+            before_shell[0].get("command").and_then(Value::as_str),
+            Some(CURSOR_BLOCKED_COMMAND)
+        );
     }
 
     #[test]
@@ -1122,6 +1184,9 @@ mod tests {
             .expect("render hooks");
         assert!(rendered.contains("UserPromptSubmit"));
         assert!(rendered.contains("--status working"));
+        assert!(rendered.contains("PermissionRequest"));
+        assert!(rendered.contains("permission_prompt|idle_prompt|elicitation_dialog"));
+        assert!(rendered.contains("--status blocked"));
         assert!(rendered.contains("--status idle"));
         assert!(rendered.contains(".claude/settings.local.json"));
         assert!(rendered.contains("~/.claude/settings.json"));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1151,16 +1151,19 @@ impl PaneSelector {
 
 fn pane_status_options() -> Vec<(String, Option<crate::context::AgentStatus>)> {
     vec![
+        ("idle".to_string(), Some(crate::context::AgentStatus::Idle)),
         (
             "working".to_string(),
             Some(crate::context::AgentStatus::Working),
         ),
         (
-            "waiting".to_string(),
-            Some(crate::context::AgentStatus::Waiting),
+            "blocked".to_string(),
+            Some(crate::context::AgentStatus::Blocked),
         ),
-        ("done".to_string(), Some(crate::context::AgentStatus::Done)),
-        ("none".to_string(), Some(crate::context::AgentStatus::None)),
+        (
+            "unknown".to_string(),
+            Some(crate::context::AgentStatus::Unknown),
+        ),
     ]
 }
 
@@ -1442,10 +1445,10 @@ fn status_text(status: Option<&crate::context::AgentStatus>) -> String {
 
 fn status_style(status: Option<&crate::context::AgentStatus>) -> Style {
     match status {
-        Some(crate::context::AgentStatus::Done) => Style::default().fg(Color::Green),
-        Some(crate::context::AgentStatus::None) => Style::default().fg(Color::Gray),
+        Some(crate::context::AgentStatus::Idle) => Style::default().fg(Color::Yellow),
         Some(crate::context::AgentStatus::Working) => Style::default().fg(Color::Blue),
-        Some(crate::context::AgentStatus::Waiting) => Style::default().fg(Color::Yellow),
+        Some(crate::context::AgentStatus::Blocked) => Style::default().fg(Color::Red),
+        Some(crate::context::AgentStatus::Unknown) => Style::default().fg(Color::Gray),
         None => Style::default(),
     }
 }
@@ -1614,7 +1617,7 @@ esac
 
     #[test]
     fn status_text_uses_default_for_missing() {
-        assert_eq!(status_text(Some(&AgentStatus::Done)), "done");
+        assert_eq!(status_text(Some(&AgentStatus::Idle)), "idle");
         assert_eq!(status_text(None), DATA_NOT_RECEIVED);
     }
 
@@ -1667,7 +1670,7 @@ esac
                 window_id: Some("@10".to_string()),
                 window_name: Some("editor".to_string()),
                 pane_name: Some("pane-two".to_string()),
-                pane_status: Some(AgentStatus::Done),
+                pane_status: Some(AgentStatus::Blocked),
                 pane_context: Some("pctx".to_string()),
             },
         );
@@ -1722,7 +1725,7 @@ esac
         assert_eq!(alpha.windows[0].panes[0].context, DATA_NOT_RECEIVED);
         assert_eq!(alpha.windows[0].panes[1].id, "%2");
         assert_eq!(alpha.windows[0].panes[1].alias.as_deref(), Some("pane-two"));
-        assert_eq!(alpha.windows[0].panes[1].status, Some(AgentStatus::Done));
+        assert_eq!(alpha.windows[0].panes[1].status, Some(AgentStatus::Blocked));
         assert_eq!(alpha.windows[0].panes[1].context, "pctx");
     }
 
@@ -1797,7 +1800,7 @@ esac
                         id: "%1".to_string(),
                         window_id: "@10".to_string(),
                         alias: Some("deploy-pane".to_string()),
-                        status: Some(AgentStatus::Waiting),
+                        status: Some(AgentStatus::Idle),
                         context: "pctx".to_string(),
                         session_id: "@1".to_string(),
                     }],
@@ -1806,7 +1809,7 @@ esac
                 WindowRow {
                     id: "@11".to_string(),
                     name: "server".to_string(),
-                    status: Some(AgentStatus::Done),
+                    status: Some(AgentStatus::Blocked),
                     context: "ops".to_string(),
                     panes: vec![PaneRow {
                         id: "%2".to_string(),

--- a/src/update.rs
+++ b/src/update.rs
@@ -251,7 +251,7 @@ fn print_post_update_notes() {
 
     println!("{accent}▸{reset} {bold}Claude Code hooks{reset}");
     println!(
-        "    {dim}Paste into Claude Code so the current pane is \"working\" while you prompt and \"idle\" when Claude stops.{reset}"
+        "    {dim}Paste into Claude Code so the current pane is \"working\" while you prompt, \"blocked\" for permission/user prompts, and \"idle\" when Claude stops.{reset}"
     );
     println!("    {dim}UserPromptSubmit:{reset}");
     println!("        {WORKING_HOOK_COMMAND}");

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,7 +8,7 @@ const REPO_OWNER: &str = "cruzluna";
 const REPO_NAME: &str = "jkl-2";
 const BIN_NAME: &str = "jkl";
 const WORKING_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
-const WAITING_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status waiting";
+const IDLE_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateChannel {
@@ -250,20 +250,20 @@ fn print_post_update_notes() {
 
     println!("{accent}▸{reset} {bold}Claude Code hooks{reset}");
     println!(
-        "    {dim}Paste into Claude Code so the current pane is \"working\" while you prompt and \"waiting\" when Claude stops.{reset}"
+        "    {dim}Paste into Claude Code so the current pane is \"working\" while you prompt and \"idle\" when Claude stops.{reset}"
     );
     println!("    {dim}UserPromptSubmit:{reset}");
     println!("        {WORKING_HOOK_COMMAND}");
     println!("    {dim}Stop:{reset}");
-    println!("        {WAITING_HOOK_COMMAND}");
+    println!("        {IDLE_HOOK_COMMAND}");
     println!();
 
     println!("{accent}▸{reset} {bold}Kiro CLI hooks{reset}");
-    println!("    {dim}Paste into Kiro CLI for the same working / waiting behavior.{reset}");
+    println!("    {dim}Paste into Kiro CLI for the same working / idle behavior.{reset}");
     println!("    {dim}userPromptSubmit:{reset}");
     println!("        {WORKING_HOOK_COMMAND}");
     println!("    {dim}stop:{reset}");
-    println!("        {WAITING_HOOK_COMMAND}");
+    println!("        {IDLE_HOOK_COMMAND}");
     println!();
 
     println!("{accent}▸{reset} {bold}tmux + TPM{reset}");

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,6 +8,7 @@ const REPO_OWNER: &str = "cruzluna";
 const REPO_NAME: &str = "jkl-2";
 const BIN_NAME: &str = "jkl";
 const WORKING_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status working";
+const BLOCKED_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status blocked";
 const IDLE_HOOK_COMMAND: &str = "[ -n \"$TMUX\" ] || exit 0; jkl upsert \"$(tmux display-message -p '#S')\" --session-id \"$(tmux display-message -p '#{session_id}')\" --pane-id \"$(tmux display-message -p '#{pane_id}')\" --status idle";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -254,13 +255,19 @@ fn print_post_update_notes() {
     );
     println!("    {dim}UserPromptSubmit:{reset}");
     println!("        {WORKING_HOOK_COMMAND}");
+    println!("    {dim}PermissionRequest / Notification permission prompts:{reset}");
+    println!("        {BLOCKED_HOOK_COMMAND}");
     println!("    {dim}Stop:{reset}");
     println!("        {IDLE_HOOK_COMMAND}");
     println!();
 
     println!("{accent}▸{reset} {bold}Kiro CLI hooks{reset}");
-    println!("    {dim}Paste into Kiro CLI for the same working / idle behavior.{reset}");
+    println!("    {dim}Paste into Kiro CLI for working / blocked / idle behavior.{reset}");
     println!("    {dim}userPromptSubmit:{reset}");
+    println!("        {WORKING_HOOK_COMMAND}");
+    println!("    {dim}preToolUse:{reset}");
+    println!("        {BLOCKED_HOOK_COMMAND}");
+    println!("    {dim}postToolUse:{reset}");
     println!("        {WORKING_HOOK_COMMAND}");
     println!("    {dim}stop:{reset}");
     println!("        {IDLE_HOOK_COMMAND}");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Replace advertised status values with `idle`, `working`, `blocked`, and `unknown`.
- Update CLI/TUI status handling, hook-generated commands, autocomplete, installer/update prompts, and docs.
- Add explicit `blocked` hook commands for Claude permission/user-input waits, plus Kiro and Cursor pre-action hook integrations.
- Preserve legacy parse/deserialization aliases for existing `waiting`, `done`, and `none` context values.

### Testing
- `cargo test --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets`
- CLI smoke test: persisted `blocked` via `jkl upsert` and verified Cursor hook prompts emit `--status idle` without `--status waiting`.
- Hook prompt smoke test: verified Claude, Kiro, and Cursor prompts all emit `--status blocked`, `--status working`, and `--status idle`, with blocked-specific events present.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b3939d2-3ba2-4eb2-aa98-5f1f378d9623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b3939d2-3ba2-4eb2-aa98-5f1f378d9623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

